### PR TITLE
feat(cip-1694): add mobile version of the leaderboard and vote pages

### DIFF
--- a/ui/cip-1694/src/App.tsx
+++ b/ui/cip-1694/src/App.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
-import { Toaster } from 'react-hot-toast';
+import toast, { Toaster } from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import CssBaseline from '@mui/material/CssBaseline';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { env } from 'env';
 import * as referenceDataService from 'common/api/referenceDataService';
 import { setEventData } from 'common/store/userSlice';
 import { Layout } from 'components/common/Layout/Layout';
+import { Toast } from 'components/common/Toast/Toast';
 import Content from './components/common/Content/Content';
 import { Footer } from './components/common/Footer/Footer';
 import { Header } from './components/common/Header/Header';
@@ -14,8 +16,18 @@ import styles from './App.module.scss';
 export const App = () => {
   const dispatch = useDispatch();
   const fetchEvent = useCallback(async () => {
-    const event = await referenceDataService.getEvent(env.EVENT_ID);
-    dispatch(setEventData({ event }));
+    try {
+      const event = await referenceDataService.getEvent(env.EVENT_ID);
+      dispatch(setEventData({ event }));
+    } catch (error) {
+      const message = `Failed to fetch event, ${error?.info || error?.message || error?.toString()}`;
+      toast(
+        <Toast
+          message={message}
+          icon={<ErrorOutlineIcon style={{ color: '#cc0e00' }} />}
+        />
+      );
+    }
   }, [dispatch]);
 
   useEffect(() => {

--- a/ui/cip-1694/src/common/api/voteService.ts
+++ b/ui/cip-1694/src/common/api/voteService.ts
@@ -10,11 +10,6 @@ import {
   VoteReceipt,
 } from '../../types/backend-services-types';
 
-export const getEventById = async (eventId: Event['id']) =>
-  await doRequest<Vote>(HttpMethods.GET, `${env.EVENT_BY_ID_REFERENCE_URL}/${eventId}`, {
-    ...DEFAULT_CONTENT_TYPE_HEADERS,
-  });
-
 export const castAVoteWithDigitalSignature = async (jsonRequest: SignedWeb3Request) =>
   await doRequest<Problem | Vote>(
     HttpMethods.POST,

--- a/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.module.scss
+++ b/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.module.scss
@@ -1,10 +1,9 @@
 .dialogTitle {
   background: #f5f9ff !important;
-  padding: 30px 30px 20px 30px !important;
   color: #061d3c !important;
   font-size: 28px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   line-height: normal !important;
 }
 
@@ -18,7 +17,6 @@
 
 .dialogContent {
   background: #f5f9ff !important;
-  padding: 0px 30px 30px 30px !important;
 }
 
 .closeBtn {

--- a/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -35,6 +35,7 @@ export const ConnectWalletModal = (props: ConnectWalletModalProps) => {
       PaperProps={{ sx: { width: '400px', borderRadius: '16px' } }}
     >
       <DialogTitle
+        sx={{ padding: { xs: '20px', ms: '30px 30px 20px 30px' } }}
         className={styles.dialogTitle}
         id={id}
       >
@@ -47,7 +48,10 @@ export const ConnectWalletModal = (props: ConnectWalletModalProps) => {
           <CloseIcon className={styles.closeIcon} />
         </IconButton>
       </DialogTitle>
-      <DialogContent className={styles.dialogContent}>
+      <DialogContent
+        sx={{ padding: { xs: '20px', ms: '0px 30px 30px 30px' } }}
+        className={styles.dialogContent}
+      >
         <DialogContentText component={'div'}>
           <Grid
             container

--- a/ui/cip-1694/src/components/OptionCard/OptionCard.module.scss
+++ b/ui/cip-1694/src/components/OptionCard/OptionCard.module.scss
@@ -1,30 +1,24 @@
-.optionCardGrouo {
-  gap: 51px;
-  margin: 40px 0;
-  .optionCard {
-    border-radius: 16px !important;
-    border: 1px solid transparent !important;
-    box-shadow: 2px 2px 5px 0px rgba(6, 29, 60, 0.25) !important;
-    display: flex;
-    flex-direction: column;
-    height: 138px;
-    margin: 0px !important;
-    width: 100%;
+.optionCard {
+  border: 1px solid transparent !important;
+  box-shadow: 2px 2px 5px 0px rgba(6, 29, 60, 0.25) !important;
+  display: flex;
+  flex-direction: column;
+  margin: 0px !important;
+  width: 100%;
 
-    &.selected,
-    &:hover,
-    &:active {
-      background: rgba(29, 67, 155, 0.1) !important;
-      border: 1px solid #1d439b !important;
-      box-shadow: 2px 2px 5px 0px rgba(29, 67, 155, 0.25) !important;
-    }
+  &.selected,
+  &:hover,
+  &:active {
+    background: rgba(29, 67, 155, 0.1) !important;
+    border: 1px solid #1d439b !important;
+    box-shadow: 2px 2px 5px 0px rgba(29, 67, 155, 0.25) !important;
   }
+}
 
-  .label {
-    color: #39486C;
-    font-size: 18px;
-    font-weight: 500;
-    line-height: normal;
-    text-transform: none;
-  }
+.label {
+  color: #39486c !important;
+  font-size: 18px !important;
+  font-weight: 600 !important;
+  line-height: normal !important;
+  text-transform: none !important;
 }

--- a/ui/cip-1694/src/components/OptionCard/OptionCard.tsx
+++ b/ui/cip-1694/src/components/OptionCard/OptionCard.tsx
@@ -26,31 +26,42 @@ export const OptionCard = ({ items, onChangeOption, disabled, selectedOption }: 
     <Grid
       container
       direction="row"
-      justifyContent={'center'}
-      width={'flex'}
+      justifyContent="center"
+      width="flex"
+      margin={{ md: '40px 0px', xs: '25px 0px' }}
     >
       <ToggleButtonGroup
         disabled={disabled}
-        sx={{ width: '100%' }}
+        sx={{ width: '100%', flexDirection: { xs: 'column', md: 'row' }, gap: { xs: '20px', md: '51px' } }}
         color="primary"
         value={active}
         exclusive
         onChange={handleChange}
         aria-label="cip-1694 poll options"
-        className={styles.optionCardGrouo}
       >
         {items.map((option) => (
           <ToggleButton
+            sx={{
+              height: { xs: '62px', md: '138px' },
+              borderRadius: { xs: '8px !important', md: '16px !important' },
+              padding: '0px 20px',
+              maxWidth: 'auto',
+            }}
             value={option.label}
             className={cn(styles.optionCard, { [styles.selected]: active === option.label })}
             key={option.label}
           >
             <Grid
               item
-              sm={4}
+              md={4}
               xs={12}
+              container
+              direction={{ xs: 'row', md: 'column' }}
+              gap="15px"
+              justifyContent={{ md: 'center', xs: 'flex-start' }}
+              alignItems="center"
             >
-              <Typography component="div">{option.icon}</Typography>
+              {option.icon}
               <Typography
                 className={styles.label}
                 component="div"

--- a/ui/cip-1694/src/components/VoteSubmittedModal/VoteSubmittedModal.module.scss
+++ b/ui/cip-1694/src/components/VoteSubmittedModal/VoteSubmittedModal.module.scss
@@ -1,10 +1,9 @@
 .dialogTitle {
   background: #f5f9ff !important;
-  padding: 30px 30px 20px 30px !important;
   color: #061d3c !important;
   font-size: 28px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   line-height: normal !important;
 }
 
@@ -18,7 +17,6 @@
 
 .dialogContent {
   background: #f5f9ff !important;
-  padding: 0px 30px 30px 30px !important;
 }
 
 .closeBtn {
@@ -38,7 +36,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;

--- a/ui/cip-1694/src/components/VoteSubmittedModal/VoteSubmittedModal.tsx
+++ b/ui/cip-1694/src/components/VoteSubmittedModal/VoteSubmittedModal.tsx
@@ -28,6 +28,7 @@ export const VoteSubmittedModal = (props: VoteSubmittedModalProps) => {
       PaperProps={{ sx: { width: '400px', borderRadius: '16px' } }}
     >
       <DialogTitle
+        sx={{ padding: { xs: '20px', ms: '30px 30px 20px 30px' } }}
         className={styles.dialogTitle}
         id={id}
       >
@@ -40,7 +41,10 @@ export const VoteSubmittedModal = (props: VoteSubmittedModalProps) => {
           <CloseIcon className={styles.closeIcon} />
         </IconButton>
       </DialogTitle>
-      <DialogContent className={styles.dialogContent}>
+      <DialogContent
+        sx={{ padding: { xs: '20px', ms: '0px 30px 30px 30px' } }}
+        className={styles.dialogContent}
+      >
         <DialogContentText component={'div'}>
           <Grid
             container

--- a/ui/cip-1694/src/components/common/Footer/Footer.tsx
+++ b/ui/cip-1694/src/components/common/Footer/Footer.tsx
@@ -25,7 +25,7 @@ export const Footer = ({ isMobileMenu = false }) => (
       xs: '1px solid #bbb',
       md: 'none',
     }}
-    marginTop={{ xs: '60px', md: '0px' }}
+    marginTop={{ xs: '40px', md: '0px' }}
     paddingTop={{ xs: '40px', md: '0px' }}
     alignItems={{ xs: 'flex-start', md: 'center' }}
     flexDirection={{ xs: 'column', md: 'row' }}

--- a/ui/cip-1694/src/components/common/Header/Header.module.scss
+++ b/ui/cip-1694/src/components/common/Header/Header.module.scss
@@ -5,11 +5,9 @@
 
 .logo {
   cursor: pointer !important;
-  color: #061d3c;
-  font-size: 24px;
-  font-weight: 500;
-  letter-spacing: -0.02em;
-  line-height: 29px;
+  color: #061d3c !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.02em !important;
 }
 
 .menuButton {

--- a/ui/cip-1694/src/components/common/Header/Header.tsx
+++ b/ui/cip-1694/src/components/common/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { Grid, Button } from '@mui/material';
+import { Grid, Button, Typography } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import { RootState } from 'common/store';
 import { HeaderActions } from './components/HeaderActions';
@@ -25,42 +25,43 @@ export const Header = () => {
       <Grid
         container
         direction={{ xs: 'column', md: 'row' }}
-        justifyContent={{ xs: 'center', sm: 'space-between' }}
+        justifyContent={{ xs: 'center', md: 'space-between' }}
         className={styles.container}
-        alignContent={{ xs: 'space-between', sm: 'center' }}
+        alignContent={{ xs: 'space-between', md: 'center' }}
         justifySelf={{
           xs: 'flex-start',
         }}
-        height={{ xs: '69px', sm: 'auto', md: '69px' }}
-        marginBottom={{ sm: '40px', md: '0px' }}
+        height={{ xs: '69px', md: '69px' }}
       >
         <Grid
           item
           xs={12}
-          sm="auto"
+          md="auto"
           display="flex"
           className={styles.content}
           alignItems="center"
-          marginBottom={{ xs: '0px', sm: '15px', md: '0px' }}
-          marginTop={{ xs: '0px', sm: '15px', md: '0px' }}
+          marginBottom={{ xs: '0px', md: '0px' }}
+          marginTop={{ xs: '0px', md: '0px' }}
         >
-          <span
+          <Typography
+            lineHeight={{ sx: '23px', md: '29px' }}
+            fontSize={{ sx: '20px', md: '24px' }}
             onClick={handleLogoClick}
             className={styles.logo}
           >
             CIP-1694 Ratification
-          </span>
+          </Typography>
         </Grid>
-        <Grid display={{ xs: 'none', sm: 'flex' }}>
+        <Grid display={{ xs: 'none', md: 'flex' }}>
           <HeaderActions
             showNavigationItems={!eventHasntStarted}
             hideLeaderboard={!event?.finished}
           />
         </Grid>
         <Grid
-          display={{ xs: 'block', sm: 'none' }}
+          display={{ xs: 'block', md: 'none' }}
           item
-          sm="auto"
+          md="auto"
           gap="15px"
           alignItems="center"
           justifyContent="flex-end"

--- a/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.module.scss
+++ b/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.module.scss
@@ -17,7 +17,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;

--- a/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.tsx
@@ -116,7 +116,7 @@ export const ConnectWalletButton = ({ isMobileMenu = false }) => {
           max-height: 49px;
           font-size: 16px;
           font-style: normal;
-          font-weight: 500;
+          font-weight: 600;
           line-height: normal;
         }
         :hover button {

--- a/ui/cip-1694/src/components/common/Header/components/HeaderActions.module.scss
+++ b/ui/cip-1694/src/components/common/Header/components/HeaderActions.module.scss
@@ -1,7 +1,7 @@
 .button {
   color: #061d3c !important;
   font-size: 16px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   line-height: normal !important;
   padding: 15px 25px !important;
   text-transform: none !important;

--- a/ui/cip-1694/src/components/common/Header/components/HeaderActions.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/HeaderActions.tsx
@@ -29,7 +29,7 @@ export const HeaderActions = ({
     <Grid
       display="flex"
       item
-      gap={{ xs: '10px', sm: '15px' }}
+      gap={{ xs: '10px', md: '15px' }}
       alignItems="center"
       justifyContent="flex-end"
       direction={{ xs: 'column', md: 'row' }}
@@ -38,7 +38,7 @@ export const HeaderActions = ({
       {showNavigationItems && (
         <>
           <Grid
-            width={{ xs: '100% !important', sm: 'auto !important' }}
+            width={{ xs: '100% !important', md: 'auto !important' }}
             container
           >
             <Button
@@ -53,12 +53,12 @@ export const HeaderActions = ({
           </Grid>
           {!hideLeaderboard && (
             <Grid
-              width={{ xs: '100% !important', sm: 'auto !important' }}
+              width={{ xs: '100% !important', md: 'auto !important' }}
               container
             >
               <Button
                 onClick={onClick}
-                sx={{ xs: { width: '100% !important' }, sm: { width: 'auto !important' } }}
+                sx={{ xs: { width: '100% !important' }, md: { width: 'auto !important' } }}
                 component={Link}
                 to={isConnected ? ROUTES.LEADERBOARD : undefined}
                 className={cn(styles.button, { [styles.activeRoute]: !!matchPath(pathname, ROUTES.LEADERBOARD) })}
@@ -77,7 +77,7 @@ export const HeaderActions = ({
         align="center"
         component="div"
         marginLeft={{ xs: '0', md: '10px' }}
-        width={{ xs: '100%', sm: 'auto' }}
+        width={{ xs: '100%', md: 'auto' }}
       >
         <ConnectWalletButton isMobileMenu={isMobileMenu} />
       </Typography>

--- a/ui/cip-1694/src/components/common/MobileModal/MobileModal.module.scss
+++ b/ui/cip-1694/src/components/common/MobileModal/MobileModal.module.scss
@@ -4,7 +4,7 @@
   color: #061d3c !important;
   font-size: 28px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   line-height: normal !important;
   display: flex;
   justify-content: space-between;
@@ -45,7 +45,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;

--- a/ui/cip-1694/src/components/common/MobileModal/MobileModal.tsx
+++ b/ui/cip-1694/src/components/common/MobileModal/MobileModal.tsx
@@ -22,7 +22,16 @@ export const MobileModal = (props: VoteSubmittedModalProps) => {
     <Dialog
       open={openStatus}
       aria-labelledby={name}
-      PaperProps={{ sx: { width: '100vw', borderRadius: '0px', margin: '0px', height: '100vh', minHeight: '100vh' } }}
+      PaperProps={{
+        sx: {
+          width: '100vw',
+          borderRadius: '0px',
+          margin: '0px',
+          height: '100vh',
+          minHeight: '100vh',
+          maxWidth: '100vw',
+        },
+      }}
     >
       <DialogTitle
         className={styles.dialogTitle}

--- a/ui/cip-1694/src/components/common/SidePage/SidePage.module.scss
+++ b/ui/cip-1694/src/components/common/SidePage/SidePage.module.scss
@@ -1,3 +1,4 @@
 .root {
   background: #f5f9ff !important;
+  max-width: 100vw !important;
 }

--- a/ui/cip-1694/src/components/common/Slides/Slides.module.scss
+++ b/ui/cip-1694/src/components/common/Slides/Slides.module.scss
@@ -94,7 +94,7 @@
 
 .title {
   color: #061d3c !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   letter-spacing: normal !important;
   margin-bottom: 12px !important;
 }
@@ -113,7 +113,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;

--- a/ui/cip-1694/src/components/common/Toast/Toast.module.scss
+++ b/ui/cip-1694/src/components/common/Toast/Toast.module.scss
@@ -3,6 +3,8 @@
   background: #061d3c;
   display: flex;
   gap: 8px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 
   .toastIcon {
     font-size: 19px !important;
@@ -10,7 +12,7 @@
   }
 
   .divider {
-    height: 22px;
+    height: 100%;
     width: 1px;
     background: #f5f9ffa6;
   }

--- a/ui/cip-1694/src/pages/Introduction/Introduction.tsx
+++ b/ui/cip-1694/src/pages/Introduction/Introduction.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from 'common/store';
 import { Slides } from '../../components/common/Slides/Slides';
 import { SlideItem } from '../../components/common/Slides/Slides.types';
 import './Introduction.scss';
 
 const Introduction = () => {
-  const event = useSelector((state: RootState) => state.user.event);
-
   const items: SlideItem[] = [
     {
       image: '/static/cip-1694-community-workshop.jpeg',
-      title: event?.presentationName,
+      title: 'What is CIP-1694 voting?',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magnaaliqua. Sit amet justo donec enim diam vulputate.',
     },

--- a/ui/cip-1694/src/pages/Leaderboard/Leaderboard.module.scss
+++ b/ui/cip-1694/src/pages/Leaderboard/Leaderboard.module.scss
@@ -1,25 +1,21 @@
 .leaderboard {
-  padding-top: 30px;
   .title {
     color: #061d3c;
-    font-size: 56px;
-    font-weight: 500;
-    line-height: normal;
-    margin-bottom: 40px;
+    font-weight: 600;
     text-align: left;
   }
 
   .optionTitle {
-    color: #061d3c !important;
+    color: #39486c !important;
     font-size: 18px !important;
-    font-weight: 500 !important;
+    font-weight: 600 !important;
     line-height: 22px !important;
     letter-spacing: 0em !important;
   }
 
   .statTitle {
     font-size: 16px !important;
-    color: #061d3c !important;
+    color: #39486c !important;
     font-weight: 400 !important;
   }
   .divider {

--- a/ui/cip-1694/src/pages/Leaderboard/Leaderboard.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/Leaderboard.tsx
@@ -3,13 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { capitalize } from 'lodash';
 import cn from 'classnames';
+import toast from 'react-hot-toast';
 import { PieChart } from 'react-minimal-pie-chart';
 import { Grid, Typography } from '@mui/material';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { useCardano } from '@cardano-foundation/cardano-connect-with-wallet';
 import { ByCategory } from 'types/backend-services-types';
 import { ROUTES } from 'common/routes';
 import { RootState } from 'common/store';
 import * as leaderboardService from 'common/api/leaderboardService';
+import { Toast } from 'components/common/Toast/Toast';
 import { proposalColorsMap, proposalOptions } from './utils';
 import { StatsTile } from './components/StatsTile';
 import styles from './Leaderboard.module.scss';
@@ -31,7 +34,14 @@ export const Leaderboard = () => {
     try {
       setStats((await leaderboardService.getStats())?.proposals);
     } catch (error) {
-      console.log('Failed to fecth stats', error?.message);
+      const message = `Failed to fecth stats: ${error?.message || error?.toString()}`;
+      console.log(message);
+      toast(
+        <Toast
+          message={message}
+          icon={<ErrorOutlineIcon style={{ color: '#cc0e00' }} />}
+        />
+      );
     }
   }, []);
 
@@ -46,6 +56,7 @@ export const Leaderboard = () => {
   return (
     <div className={styles.leaderboard}>
       <Grid
+        paddingTop={{ xs: '20px', md: '30px' }}
         container
         direction="column"
         justifyContent="left"
@@ -56,6 +67,15 @@ export const Leaderboard = () => {
           <Typography
             variant="h5"
             className={styles.title}
+            fontSize={{
+              xs: '28px',
+              md: '56px',
+            }}
+            lineHeight={{
+              xs: '33px',
+              md: '65px',
+            }}
+            marginBottom={{ md: '40px', xs: '25px' }}
           >
             Leaderboard
           </Typography>
@@ -63,13 +83,13 @@ export const Leaderboard = () => {
         <Grid
           container
           spacing={0}
-          gridRow={{ sm: 6, xs: 12 }}
-          gap="46px"
-          wrap="nowrap"
+          gridRow={{ md: 6, xs: 12 }}
+          gap={{ md: '46px', xs: '25px' }}
+          sx={{ flexWrap: { md: 'nowrap', xs: 'wrap' } }}
         >
           <StatsTile
-            title="Current voting stats"
-            summary={<span>{statsSum}</span>}
+            title="Poll stats"
+            summary={<span style={{ color: '#061d3c' }}>{statsSum}</span>}
           >
             <Grid
               container
@@ -121,14 +141,14 @@ export const Leaderboard = () => {
           </StatsTile>
           <StatsTile
             title="Current voting stats"
-            summary={<span>{statsSum}</span>}
+            summary={<span style={{ color: '#061d3c' }}>{statsSum}</span>}
           >
             <Grid
               container
-              direction="row"
-              gridRow={{ sm: 6, xs: 12 }}
-              wrap="nowrap"
-              sx={{ marginTop: '8px' }}
+              direction={{ md: 'row', xs: 'column-reverse' }}
+              gridRow={{ md: 6, xs: 12 }}
+              sx={{ flexWrap: { md: 'nowrap', xs: 'wrap' }, marginTop: { md: '8px', xs: '25px' } }}
+              gap={{ xs: '25px', md: 'none' }}
             >
               <Grid
                 container
@@ -163,7 +183,7 @@ export const Leaderboard = () => {
               <Grid
                 item
                 container
-                justifyContent="space-between"
+                justifyContent={{ md: 'space-between', xs: 'center' }}
               >
                 <PieChart
                   style={{ height: '200px', width: '200px' }}

--- a/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.module.scss
+++ b/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.module.scss
@@ -5,21 +5,18 @@
   display: flex !important;
   flex-direction: column !important;
   margin: 0px !important;
-  padding: 30px;
 
   .optionTitle {
-    color: #061d3c !important;
+    color: #39486c !important;
     font-size: 18px !important;
-    font-weight: 500 !important;
+    font-weight: 600 !important;
     line-height: 22px !important;
     letter-spacing: 0em !important;
   }
 
   .optionSummary {
     color: #39486c !important;
-    font-size: 40px !important;
-    font-weight: 500 !important;
-    line-height: 47px !important;
+    font-weight: 600 !important;
     letter-spacing: 0em !important;
     text-align: left !important;
   }

--- a/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.tsx
@@ -12,9 +12,10 @@ export const StatsTile = ({ title, summary, children }: StatsTilePorps) => {
   return (
     <Grid
       xs={12}
-      sm={6}
+      md={6}
       item
       className={styles.optionCard}
+      padding={{ md: '30px', xs: '20px' }}
     >
       <Grid
         container
@@ -30,6 +31,10 @@ export const StatsTile = ({ title, summary, children }: StatsTilePorps) => {
         </Typography>
         <Typography
           variant="h5"
+          sx={{
+            fontSize: { md: '40px', xs: '28px' },
+            lineHeight: { md: '47px', xs: '32px' },
+          }}
           className={styles.optionSummary}
         >
           {summary}

--- a/ui/cip-1694/src/pages/Vote/Vote.module.scss
+++ b/ui/cip-1694/src/pages/Vote/Vote.module.scss
@@ -1,42 +1,38 @@
 .vote {
-  padding-top: 30px;
   .title {
-    color: #061d3c;
-    font-size: 56px;
-    font-weight: 500;
-    line-height: normal;
-    margin-bottom: 12px;
-    text-align: left;
+    color: #061d3c !important;
+    font-weight: 600 !important;
+    margin-bottom: 12px !important;
+    text-align: left !important;
   }
 
   .description {
-    color: #061d3c;
-    font-size: 28px;
-    font-weight: 500;
-    line-height: 36px;
+    color: #061d3c !important;
+    font-weight: 600 !important;
+    letter-spacing: 0em !important;
   }
 
   .button {
     background: #1d439b;
-    border-radius: 8px;
+    border-radius: 8px !important;
     color: #f5f9ff !important;
-    font-size: 16px;
-    font-style: normal;
-    font-weight: 500;
-    height: 49px;
-    line-height: normal;
-    text-transform: unset;
-    white-space: nowrap;
-    width: 348px;
-    box-shadow: none;
+    font-size: 16px !important;
+    font-style: normal !important;
+    font-weight: 600 !important;
+    height: 49px !important;
+    line-height: normal !important;
+    text-transform: unset !important;
+    white-space: nowrap !important;
+    width: 348px !important;
+    box-shadow: none !important;
     &.secondary {
       border: 1px solid #bbb;
       color: #39486c !important;
       background: #f5f9ff;
       &:hover {
-        border: 1px solid #1d439b;
-        background: rgba(29, 67, 155, 0.1);
-        box-shadow: 2px 2px 5px 0px rgba(29, 67, 155, 0.25);
+        border: 1px solid #1d439b !important;
+        background: rgba(29, 67, 155, 0.1) !important;
+        box-shadow: 2px 2px 5px 0px rgba(29, 67, 155, 0.25) !important;
       }
     }
     &.disabled {

--- a/ui/cip-1694/src/pages/Vote/Vote.tsx
+++ b/ui/cip-1694/src/pages/Vote/Vote.tsx
@@ -47,15 +47,15 @@ const errorsMap = {
 const items: OptionItem[] = [
   {
     label: 'yes',
-    icon: <DoneIcon sx={{ fontSize: 52, color: '#39486C' }} />,
+    icon: <DoneIcon sx={{ fontSize: { xs: '30px', md: '52px' }, color: '#39486C' }} />,
   },
   {
     label: 'no',
-    icon: <CloseIcon sx={{ fontSize: 52, color: '#39486C' }} />,
+    icon: <CloseIcon sx={{ fontSize: { xs: '30px', md: '52px' }, color: '#39486C' }} />,
   },
   {
     label: 'abstain',
-    icon: <DoDisturbIcon sx={{ fontSize: 52, color: '#39486C' }} />,
+    icon: <DoDisturbIcon sx={{ fontSize: { xs: '30px', md: '52px' }, color: '#39486C' }} />,
   },
 ];
 
@@ -103,6 +103,12 @@ const Vote = () => {
         } else {
           const message = `Failed to fetch receipt', ${receiptResponse?.title}, ${receiptResponse?.detail}`;
           console.log(message);
+          toast(
+            <Toast
+              message={message}
+              icon={<ErrorOutlineIcon style={{ color: '#cc0e00' }} />}
+            />
+          );
         }
         dispatch(setIsReceiptFetched({ isFetched: true }));
         cb?.();
@@ -133,7 +139,14 @@ const Vote = () => {
     try {
       setAbsoluteSlot((await voteService.getSlotNumber())?.absoluteSlot);
     } catch (error) {
-      console.log('Failed to fecth slot number', error?.message);
+      const message = `Failed to fecth slot number: ${error?.message}`;
+      console.log(message);
+      toast(
+        <Toast
+          message={message}
+          icon={<ErrorOutlineIcon style={{ color: '#cc0e00' }} />}
+        />
+      );
     }
   }, []);
 
@@ -224,6 +237,7 @@ const Vote = () => {
     <>
       <div className={styles.vote}>
         <Grid
+          paddingTop={{ xs: '20px', md: '30px' }}
           container
           direction="column"
           justifyContent="left"
@@ -234,16 +248,20 @@ const Vote = () => {
             <Typography
               variant="h5"
               className={styles.title}
+              fontSize={{
+                xs: '28px',
+                md: '56px',
+              }}
+              lineHeight={{
+                xs: '33px',
+                md: '65px',
+              }}
             >
-              {event?.presentationName}
+              CIP-1694 Vote
             </Typography>
           </Grid>
           <Grid item>
-            <Typography
-              sx={{
-                mb: '24px',
-              }}
-            >
+            <Typography marginBottom={{ xs: '38px', md: '24px' }}>
               <EventTime
                 eventHasntStarted={eventHasntStarted}
                 eventHasFinished={event?.finished}
@@ -256,13 +274,15 @@ const Vote = () => {
             <Typography
               variant="h5"
               className={styles.description}
+              lineHeight={{ xs: '19px', md: '36px' }}
+              fontSize={{ xs: '16px', md: '28px' }}
             >
               Do you want CIP-1694 that will allow On-Chain Governance, implemented on the Cardano Blockchain?
             </Typography>
           </Grid>
           <Grid item>
             <OptionCard
-              selectedOption={savedProposal?.toLowerCase()}
+              selectedOption={isConnected && savedProposal?.toLowerCase()}
               disabled={cantSelectOptions}
               items={items}
               onChangeOption={onChangeOption}

--- a/ui/cip-1694/src/pages/Vote/components/InfoPanel/InfoPanel.module.scss
+++ b/ui/cip-1694/src/pages/Vote/components/InfoPanel/InfoPanel.module.scss
@@ -24,7 +24,7 @@
 
 .title {
   font-size: 18px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 22px;
   letter-spacing: 0em;
   align-items: center;

--- a/ui/cip-1694/src/pages/Vote/components/InfoPanel/InfoPanel.tsx
+++ b/ui/cip-1694/src/pages/Vote/components/InfoPanel/InfoPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
 import cn from 'classnames';
+import { Box } from '@mui/material';
 import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import GppBadOutlinedIcon from '@mui/icons-material/GppBadOutlined';
@@ -49,8 +50,26 @@ export const InfoPanel = ({ icon, title, cta, description, type }: InfoPanelProp
   <Grid
     gap="16px"
     className={cn(styles.infoPanel, { [styles[type?.toLowerCase()]]: type })}
+    container
+    direction={{ xs: 'column', sm: 'row' }}
+    flexWrap="nowrap"
   >
-    {icon || IconsMap[type]}
+    <Grid
+      gap="0"
+      item
+      display={{ xs: 'flex', sm: 'none' }}
+      justifyContent="space-between"
+    >
+      <Grid item>{icon || IconsMap[type]}</Grid>
+      <Grid item>{cta}</Grid>
+    </Grid>
+
+    <Grid
+      display={{ xs: 'none', sm: 'flex' }}
+      item
+    >
+      {icon || IconsMap[type]}
+    </Grid>
     <Grid
       container
       direction="column"
@@ -62,7 +81,7 @@ export const InfoPanel = ({ icon, title, cta, description, type }: InfoPanelProp
         justifyContent="space-between"
       >
         <span className={styles.title}>{title}</span>
-        {cta}
+        <Box display={{ xs: 'none', sm: 'block' }}>{cta}</Box>
       </Grid>
       <Grid
         item

--- a/ui/cip-1694/src/pages/Vote/components/VerifyVote/VerifyVote.module.scss
+++ b/ui/cip-1694/src/pages/Vote/components/VerifyVote/VerifyVote.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   font-size: 28px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   gap: 12px;
   line-height: normal !important;
   padding: 30px 30px 20px 30px !important;
@@ -68,7 +68,7 @@
   border: 1px solid #bbbbbb !important;
   color: #061d3c !important;
   font-size: 16px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 100% !important;
   letter-spacing: 0em !important;
   line-height: 19px !important;
@@ -86,7 +86,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;

--- a/ui/cip-1694/src/pages/Vote/components/VoteReceipt/VoteReceipt.module.scss
+++ b/ui/cip-1694/src/pages/Vote/components/VoteReceipt/VoteReceipt.module.scss
@@ -1,6 +1,6 @@
 .title {
   font-size: 28px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   line-height: 36px !important;
   letter-spacing: 0em !important;
   text-align: center !important;
@@ -33,7 +33,7 @@
   color: #f5f9ff !important;
   font-size: 16px !important;
   font-style: normal !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   height: 49px !important;
   line-height: normal !important;
   text-transform: unset !important;
@@ -67,7 +67,7 @@
 .label {
   color: #061d3c !important;
   font-size: 18px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   letter-spacing: 0em !important;
   line-height: 22px !important;
   text-align: left !important;
@@ -92,7 +92,7 @@
   }
   .tooltipTitle {
     font-size: 18px !important;
-    font-weight: 500 !important;
+    font-weight: 600 !important;
     line-height: 22px !important;
     letter-spacing: 0em !important;
     text-align: left !important;
@@ -185,7 +185,7 @@
     cursor: pointer !important;
     display: flex !important;
     font-size: 16px !important;
-    font-weight: 500 !important;
+    font-weight: 600 !important;
     gap: 10px !important;
     height: 52px !important;
     min-height: 52px !important;

--- a/ui/cip-1694/src/pages/Vote/components/VoteReceipt/VoteReceipt.tsx
+++ b/ui/cip-1694/src/pages/Vote/components/VoteReceipt/VoteReceipt.tsx
@@ -94,7 +94,8 @@ export const VoteReceipt = ({ setOpen, fetchReceipt }: VoteReceiptProps) => {
       justifyContent="center"
       alignItems="center"
       spacing={0}
-      sx={{ padding: '30px', paddingTop: '50px', width: '550px' }}
+      maxWidth="100%"
+      sx={{ padding: { xs: '20px', md: '30px' }, paddingTop: '50px', width: '550px' }}
     >
       <IconButton
         aria-label="close"
@@ -157,7 +158,7 @@ export const VoteReceipt = ({ setOpen, fetchReceipt }: VoteReceiptProps) => {
             aria-controls="panel1a-content"
             id="panel1a-header"
           >
-            <Typography style={{ fontSize: '16px', fontWeight: '500' }}>Show advanced information</Typography>
+            <Typography style={{ fontSize: '16px', fontWeight: '600' }}>Show advanced information</Typography>
           </AccordionSummary>
           <AccordionDetails sx={{ padding: '0px' }}>
             {Object.entries(moreFieldsToDisplay).map(([key, value]: [AdvancedFullFieldsToDisplayArrayKeys, string]) => (


### PR DESCRIPTION
<img width="391" alt="Screenshot 2023-08-08 at 13 02 36" src="https://github.com/cardano-foundation/cf-voting-app/assets/7934077/d1a125d8-0efa-4dd2-a9a3-b78dae808b3f">
<img width="388" alt="Screenshot 2023-08-08 at 13 04 15" src="https://github.com/cardano-foundation/cf-voting-app/assets/7934077/61466e14-b0e7-46a8-8f16-e2a530408173">
<img width="391" alt="Screenshot 2023-08-08 at 13 05 06" src="https://github.com/cardano-foundation/cf-voting-app/assets/7934077/f990ef83-4658-4339-bdf3-0c581d777df9">
