### PR TITLE
feat: switching from prometheus summary to histograms

### DIFF
--- a/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/DiscordUserVerificationResource.java
+++ b/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/DiscordUserVerificationResource.java
@@ -22,7 +22,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 public class DiscordUserVerificationResource {
 
     @RequestMapping(value = "/is-verified/{hashedDiscordId}", method = GET, produces = "application/json")
-    @Timed(value = "resource.discord.isVerified", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.discord.isVerified", histogram = true)
     public ResponseEntity<?> isDiscordUserVerified(@PathVariable("hashedDiscordId") String hashedDiscordId) {
         log.info("Received isDiscordUserVerified hashedDiscordId: {}", hashedDiscordId);
 
@@ -32,7 +32,7 @@ public class DiscordUserVerificationResource {
     }
 
     @RequestMapping(value = "/start-verification", method = POST, produces = "application/json")
-    @Timed(value = "resource.discord.startVerification", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.discord.startVerification", histogram = true)
     public ResponseEntity<?> startVerification(@RequestBody @Valid DiscordStartVerificationRequest startVerificationRequest) {
         log.info("Received discord startVerification request: {}", startVerificationRequest);
 
@@ -42,7 +42,7 @@ public class DiscordUserVerificationResource {
     }
 
     @RequestMapping(value = "/check-verification", method = POST, produces = "application/json")
-    @Timed(value = "resource.discord.checkVerification", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.discord.checkVerification", histogram = true)
     public ResponseEntity<?> checkVerification(@RequestBody @Valid DiscordCheckVerificationRequest checkVerificationRequest) {
         log.info("Received discord checkVerification request: {}", checkVerificationRequest);
 

--- a/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/SMSUserVerificationResource.java
+++ b/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/SMSUserVerificationResource.java
@@ -25,7 +25,7 @@ public class SMSUserVerificationResource {
     private final SMSUserVerificationService smsUserVerificationService;
 
     @RequestMapping(value = "/start-verification", method = POST, produces = "application/json")
-    @Timed(value = "resource.sms.startVerification", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.sms.startVerification", histogram = true)
     public ResponseEntity<?> startVerification(@RequestBody @Valid SMSStartVerificationRequest startVerificationRequest) {
         log.info("Received SMS startVerification request: {}", startVerificationRequest);
 
@@ -36,7 +36,7 @@ public class SMSUserVerificationResource {
     }
 
     @RequestMapping(value = "/check-verification", method = POST, produces = "application/json")
-    @Timed(value = "resource.sms.checkVerification", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.sms.checkVerification", histogram = true)
     public ResponseEntity<?> checkVerification(@RequestBody @Valid SMSCheckVerificationRequest checkVerificationRequest) {
         log.info("Received SMS checkVerification request: {}", checkVerificationRequest);
 

--- a/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/UserVerificationResource.java
+++ b/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/UserVerificationResource.java
@@ -23,7 +23,7 @@ public class UserVerificationResource {
     private final SMSUserVerificationService smsUserVerificationService;
 
     @RequestMapping(value = "/verified/{eventId}/{stakeAddress}", method = GET, produces = "application/json")
-    @Timed(value = "resource.isVerified", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.isVerified", histogram = true)
     public ResponseEntity<?> isVerified(@PathVariable("eventId") String eventId, @PathVariable("stakeAddress") String stakeAddress) {
         var isVerifiedRequest = new IsVerifiedRequest(stakeAddress, eventId);
 

--- a/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/service/merkle_tree/VoteMerkleProofService.java
+++ b/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/service/merkle_tree/VoteMerkleProofService.java
@@ -20,26 +20,26 @@ public class VoteMerkleProofService {
     private VoteMerkleProofRepository voteMerkleProofRepository;
 
     @Transactional(readOnly = true)
-    @Timed(value = "service.merkle.findLatestProof", percentiles = { 0.3, 0.5, 0.95 })
+    @Timed(value = "service.merkle.findLatestProof", histogram = true)
     public Optional<VoteMerkleProof> findLatestProof(String eventId, String voteId) {
         return voteMerkleProofRepository.findLatestProof(eventId, voteId);
     }
 
     @Transactional
-    @Timed(value = "service.merkle.store", percentiles = { 0.3, 0.5, 0.95 })
+    @Timed(value = "service.merkle.store", histogram = true)
     public VoteMerkleProof store(VoteMerkleProof voteMerkleProof) {
         return voteMerkleProofRepository.saveAndFlush(voteMerkleProof);
     }
 
     @Transactional
-    @Timed(value = "service.merkle.store.all", percentiles = { 0.3, 0.5, 0.95 })
+    @Timed(value = "service.merkle.store.all", histogram = true)
     public void storeAll(List<VoteMerkleProof> voteMerkleProofs) {
         voteMerkleProofRepository.saveAll(voteMerkleProofs);
         voteMerkleProofRepository.flush();
     }
 
     @Transactional
-    @Timed(value = "service.merkle.softDeleteAllProofsAfterSlot", percentiles = { 0.3, 0.5, 0.95 })
+    @Timed(value = "service.merkle.softDeleteAllProofsAfterSlot", histogram = true)
     public void softDeleteAllProofsAfterSlot(long slot) {
         log.info("Soft deleting all proofs after slot:{}", slot);
 

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/MerkleRootHashResource.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/MerkleRootHashResource.java
@@ -22,7 +22,7 @@ public class MerkleRootHashResource {
     private final MerkleRootHashService merkleRootHashService;
 
     @RequestMapping(value = "/{event}/{merkleRootHashHex}", method = GET, produces = "application/json")
-    @Timed(value = "resource.merkle_root_hash.find", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.merkle_root_hash.find", histogram = true)
     public ResponseEntity<?> isValidMerkleRootHash(@PathVariable String event, @PathVariable String merkleRootHashHex) {
         return merkleRootHashService.isPresent(event, merkleRootHashHex)
                 .fold(problem -> ResponseEntity.status(Objects.requireNonNull(problem.getStatus()).getStatusCode()).body(problem),

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/ReferenceDataResource.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/ReferenceDataResource.java
@@ -20,7 +20,7 @@ public class ReferenceDataResource {
     private ReferencePresentationService referencePresentationService;
 
     @RequestMapping(value = "/event/{name}", method = GET, produces = "application/json")
-    @Timed(value = "resource.reference.event", percentiles = { 0.3, 0.5, 0.95 } )
+    @Timed(value = "resource.reference.event", histogram = true)
     public ResponseEntity<?> getEventByName(@PathVariable String name) {
         return referencePresentationService.findEventReference(name)
                 .map(eventReference -> ResponseEntity.ok().body(eventReference)
@@ -28,7 +28,7 @@ public class ReferenceDataResource {
     }
 
     @RequestMapping(value = "/event", method = GET, produces = "application/json")
-    @Timed(value = "resource.reference.events", percentiles = { 0.3, 0.5, 0.95 } )
+    @Timed(value = "resource.reference.events", histogram = true)
     public ResponseEntity<?> events() {
         return ResponseEntity.ok(referencePresentationService.eventsData());
     }

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/service/reference_data/ReferenceDataService.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/service/reference_data/ReferenceDataService.java
@@ -37,43 +37,43 @@ public class ReferenceDataService {
     @Autowired
     private MerkleRootHashRepository merkleRootHashRepository;
 
-    @Timed(value = "service.reference.findValidEventByName", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findValidEventByName", histogram = true)
     @Transactional(readOnly = true)
     public Optional<Event> findValidEventByName(String name) {
         return eventRepository.findById(name).filter(Event::isValid);
     }
 
-    @Timed(value = "service.reference.findEventByName", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findEventByName", histogram = true)
     @Transactional(readOnly = true)
     public Optional<Event> findEventByName(String name) {
         return eventRepository.findById(name);
     }
 
-    @Timed(value = "service.reference.findCategoryByName", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findCategoryByName", histogram = true)
     @Transactional(readOnly = true)
     public Optional<Category> findCategoryByName(String name) {
         return categoryRepository.findById(name);
     }
 
-    @Timed(value = "service.reference.findProposalById", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findProposalById", histogram = true)
     @Transactional(readOnly = true)
     public Optional<Proposal> findProposalById(String id) {
         return proposalRepository.findById(id);
     }
 
-    @Timed(value = "service.reference.findProposalByName", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findProposalByName", histogram = true)
     @Transactional(readOnly = true)
     public Optional<Proposal> findProposalByName(Category category, String name) {
         return proposalRepository.findProposalByName(category.getId(), name);
     }
 
-    @Timed(value = "service.reference.storeEvent", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.storeEvent", histogram = true)
     @Transactional
     public Event storeEvent(Event event) {
         return eventRepository.saveAndFlush(event);
     }
 
-    @Timed(value = "service.reference.findAllValidEvents", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findAllValidEvents", histogram = true)
     @Transactional(readOnly = true)
     public List<Event> findAllValidEvents() {
         return eventRepository.findAll()
@@ -82,27 +82,27 @@ public class ReferenceDataService {
                 .toList();
     }
 
-    @Timed(value = "service.reference.findAllActiveEvents", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.findAllActiveEvents", histogram = true)
     @Transactional(readOnly = true)
     public List<Event> findAllActiveEvents() {
         return findAllValidEvents().stream()
                 .filter(event -> expirationService.isEventActive(event)).toList();
     }
 
-    @Timed(value = "service.reference.storeCategory", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.storeCategory", histogram = true)
     @Transactional
     public Category storeCategory(Category category) {
         return categoryRepository.saveAndFlush(category);
     }
 
-    @Timed(value = "service.reference.storeCommitments", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.storeCommitments", histogram = true)
     @Transactional
     public List<MerkleRootHash> storeCommitments(List<MerkleRootHash> merkleRootHashes) {
         log.info("Storing commitments:{}", merkleRootHashes);
         return merkleRootHashRepository.saveAllAndFlush(merkleRootHashes);
     }
 
-    @Timed(value = "service.reference.rollback", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "service.reference.rollback", histogram = true)
     @Transactional
     public void rollbackReferenceDataAfterSlot(long slot) {
         proposalRepository.deleteAllAfterSlot(slot);

--- a/backend-services/voting-verification-app/src/main/java/org/cardano/foundation/voting/resource/VerificationResource.java
+++ b/backend-services/voting-verification-app/src/main/java/org/cardano/foundation/voting/resource/VerificationResource.java
@@ -24,7 +24,7 @@ public class VerificationResource {
     private final VoteVerificationService voteVerificationService;
 
     @RequestMapping(value = "/verify-vote", method = POST, produces = "application/json")
-    @Timed(value = "resource.verifyVote", percentiles = {0.3, 0.5, 0.95})
+    @Timed(value = "resource.verifyVote", histogram = true)
     public ResponseEntity<?> verifyVote(@RequestBody @Valid VoteVerificationRequest voteVerificationRequest) {
         log.info("Received vote verification request: {}", voteVerificationRequest);
 


### PR DESCRIPTION
The default configuration for Micrometer is to produce prometheus `summary` instead of `histogram` for the Timer `@Timed` annotation.

`summaries` are great very simple and intuitive to use BUT, they cannot be aggregated in any way and also require client side computation. Especially in case of endpoints called very frequently.

This pr replaces `summary` metric object with `histograms`. This metric is again very simple and uses few bytes of memory (for the buckets) but the advantage is that such values can be aggregated over multiple instances of the same service.