### PR TITLE
fix: event start date and event end date based on absolute slot calcu…

### DIFF
--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/service/epoch/CustomEpochService.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/service/epoch/CustomEpochService.java
@@ -95,9 +95,9 @@ public class CustomEpochService {
     }
 
     public Optional<ZonedDateTime> getTimeBasedOnAbsoluteSlot(long absoluteSlotNo) {
-        var millis = blockTime(Shelley, absoluteSlotNo) * 1000;
+        var millis = blockTime(Shelley, absoluteSlotNo);
 
-        var t = LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC);
+        var t = LocalDateTime.ofInstant(Instant.ofEpochSecond(millis), UTC);
 
         return Optional.of(t.atZone(UTC));
     }


### PR DESCRIPTION
…lation fix.

@jimcase now you can actually use it on the homepage or somewhere, it works fine.

![image](https://github.com/cardano-foundation/cf-cardano-ballot/assets/335933/f39601fe-919b-4f87-9454-d89cf58af1a8)

Important detail!

You should NOT use those dates to check if event is running or NOT. For that there are special boolean flags.

![image](https://github.com/cardano-foundation/cf-cardano-ballot/assets/335933/2dfe8084-90c3-49d3-935f-8c7e530af592)


Event dates should be used only for presentation information.
