### PR TITLE
feat: Cache-Control headers and shallow eTags.

### DIFF
--- a/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/DiscordUserVerificationResource.java
+++ b/backend-services/user-verification-service/src/main/java/org/cardano/foundation/voting/resource/DiscordUserVerificationResource.java
@@ -36,10 +36,14 @@ public class DiscordUserVerificationResource {
 
         return discordUserVerificationService.isVerifiedBasedOnDiscordIdHash(discordBotEventIdBinding, discordIdHash)
                 .fold(problem -> {
-                            return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                            return ResponseEntity
+                                    .status(problem.getStatus().getStatusCode())
+                                    .body(problem);
                         },
                         userVerification -> {
-                            return ResponseEntity.ok().body(userVerification);
+                            return ResponseEntity
+                                    .ok()
+                                    .body(userVerification);
                         }
                 );
     }

--- a/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/config/CacheConfig.java
+++ b/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/config/CacheConfig.java
@@ -1,0 +1,16 @@
+package org.cardano.foundation.voting.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+@Configuration
+public class CacheConfig {
+
+    // https://asbnotebook.com/etags-in-restful-services-spring-boot/
+    @Bean
+    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
+    }
+
+}

--- a/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/resource/LeaderboardResource.java
+++ b/backend-services/voting-app/src/main/java/org/cardano/foundation/voting/resource/LeaderboardResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cardano.foundation.voting.service.leader_board.LeaderBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.cardano.foundation.voting.resource.Headers.XForceLeaderBoardResults;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
@@ -32,16 +34,26 @@ public class LeaderboardResource {
     @Timed(value = "resource.leaderboard.high.level.event.available", histogram = true)
     public ResponseEntity<?> isHighLevelEventLeaderBoardAvailable(@PathVariable("eventId") String eventId,
                                                                   @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var availableE = leaderBoardService.isHighLevelEventLeaderboardAvailable(eventId, forceLeaderboard);
 
         return availableE.fold(problem -> {
-                    return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                    return ResponseEntity
+                            .status(problem.getStatus().getStatusCode())
+                            .cacheControl(cacheControl)
+                            .body(problem);
                 },
                 isAvailable -> {
                     if (isAvailable) {
-                        return ResponseEntity.ok().build();
+                        return ResponseEntity
+                                .ok()
+                                .cacheControl(cacheControl)
+                                .build();
                     }
 
                     var problem = Problem.builder()
@@ -53,6 +65,7 @@ public class LeaderboardResource {
 
                     return ResponseEntity
                             .status(problem.getStatus().getStatusCode())
+                            .cacheControl(cacheControl)
                             .body(problem);
                 }
         );
@@ -62,16 +75,26 @@ public class LeaderboardResource {
     @Timed(value = "resource.leaderboard.high.level.category.available", histogram = true)
     public ResponseEntity<?> isHighLevelCategoryLeaderBoardAvailable(@PathVariable("eventId") String eventId,
                                                                      @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var availableE = leaderBoardService.isHighLevelCategoryLeaderboardAvailable(eventId, forceLeaderboard);
 
         return availableE.fold(problem -> {
-                    return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                    return ResponseEntity
+                            .status(problem.getStatus().getStatusCode())
+                            .cacheControl(cacheControl)
+                            .body(problem);
                 },
                 isAvailable -> {
                     if (isAvailable) {
-                        return ResponseEntity.ok().build();
+                        return ResponseEntity
+                                .ok()
+                                .cacheControl(cacheControl)
+                                .build();
                     }
                     var problem = Problem.builder()
                             .withTitle("VOTING_RESULTS_NOT_AVAILABLE")
@@ -81,6 +104,7 @@ public class LeaderboardResource {
 
                     return ResponseEntity
                             .status(problem.getStatus().getStatusCode())
+                            .cacheControl(cacheControl)
                             .body(problem);
                 }
         );
@@ -91,6 +115,10 @@ public class LeaderboardResource {
     public ResponseEntity<?> getCategoryLeaderBoardAvailable(@PathVariable("eventId") String eventId,
                                                              @PathVariable("categoryId") String categoryId,
                                                              @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var categoryLeaderboardAvailableE = leaderBoardService.isCategoryLeaderboardAvailable(eventId, categoryId, forceLeaderboard);
@@ -99,11 +127,15 @@ public class LeaderboardResource {
                 .fold(problem -> {
                             return ResponseEntity
                                     .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
                                     .body(problem);
                         },
                         isAvailable -> {
                             if (isAvailable) {
-                                return ResponseEntity.ok().build();
+                                return ResponseEntity
+                                        .ok()
+                                        .cacheControl(cacheControl)
+                                        .build();
                             }
                             var problem = Problem.builder()
                                     .withTitle("VOTING_RESULTS_NOT_AVAILABLE")
@@ -113,6 +145,7 @@ public class LeaderboardResource {
 
                             return ResponseEntity
                                     .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
                                     .body(problem);
                         }
                 );
@@ -122,15 +155,25 @@ public class LeaderboardResource {
     @Timed(value = "resource.leaderboard.event", histogram = true)
     public ResponseEntity<?> getEventLeaderBoard(@PathVariable("eventId") String eventId,
                                                  @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var eventLeaderboardE = leaderBoardService.getEventLeaderboard(eventId, forceLeaderboard);
 
         return eventLeaderboardE.fold(problem -> {
-                    return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                    return ResponseEntity
+                            .status(problem.getStatus().getStatusCode())
+                            .cacheControl(cacheControl)
+                            .body(problem);
                 },
                 response -> {
-                    return ResponseEntity.ok().body(response);
+                    return ResponseEntity
+                            .ok()
+                            .cacheControl(cacheControl)
+                            .body(response);
                 }
         );
     }
@@ -140,16 +183,26 @@ public class LeaderboardResource {
     public ResponseEntity<?> getCategoryLeaderBoard(@PathVariable("eventId") String eventId,
                                                     @PathVariable("categoryId") String categoryId,
                                                     @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var categoryLeaderboardE = leaderBoardService.getCategoryLeaderboard(eventId, categoryId, forceLeaderboard);
 
         return categoryLeaderboardE
                 .fold(problem -> {
-                            return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                            return ResponseEntity
+                                    .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
+                                    .body(problem);
                         },
                         response -> {
-                            return ResponseEntity.ok().body(response);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(response);
                         }
                 );
     }
@@ -158,6 +211,10 @@ public class LeaderboardResource {
     @Timed(value = "resource.leaderboard.category.winners", histogram = true)
     public ResponseEntity<?> getWinners(@PathVariable("eventId") String eventId,
                                         @RequestHeader(value = XForceLeaderBoardResults, required = false, defaultValue = "false") boolean forceLeaderboardResults) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         var forceLeaderboard = forceLeaderboardResults && forceLeaderboardResultsAvailability;
 
         var categoryLeaderboardE = leaderBoardService.getEventWinners(eventId, forceLeaderboard);
@@ -166,11 +223,14 @@ public class LeaderboardResource {
                 .fold(problem -> {
                             return ResponseEntity
                                     .status(problem.getStatus().getStatusCode())
-                                    //.cacheControl(noCache())
+                                    .cacheControl(cacheControl)
                                     .body(problem);
                         },
                         response -> {
-                            return ResponseEntity.ok().body(response);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(response);
                         }
                 );
     }

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/config/CacheConfig.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/config/CacheConfig.java
@@ -1,0 +1,16 @@
+package org.cardano.foundation.voting.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+@Configuration
+public class CacheConfig {
+
+    // https://asbnotebook.com/etags-in-restful-services-spring-boot/
+    @Bean
+    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
+    }
+
+}

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/AccountResource.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/AccountResource.java
@@ -4,11 +4,13 @@ import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cardano.foundation.voting.service.account.AccountService;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static java.util.concurrent.TimeUnit.HOURS;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 @RestController
@@ -23,14 +25,22 @@ public class AccountResource {
     @Timed(value = "resource.account.find", histogram = true)
     public ResponseEntity<?> findAccount(@PathVariable("eventId") String eventId,
                                          @PathVariable String stakeAddress) {
+        var cacheControl = CacheControl.maxAge(1, HOURS)
+                .noTransform()
+                .mustRevalidate();
+
         return accountService.findAccount(eventId, stakeAddress)
                 .fold(problem -> {
                             return ResponseEntity
                                     .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
                                     .body(problem);
                         },
                         account -> {
-                            return ResponseEntity.ok().body(account);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(account);
                         });
     }
 

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/MerkleRootHashResource.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/MerkleRootHashResource.java
@@ -4,11 +4,13 @@ import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cardano.foundation.voting.service.vote.MerkleRootHashService;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 @Controller
@@ -23,14 +25,22 @@ public class MerkleRootHashResource {
     @Timed(value = "resource.merkle_root_hash.find", histogram = true)
     public ResponseEntity<?> isValidMerkleRootHash(@PathVariable("eventId") String eventId,
                                                    @PathVariable("merkleRootHashHex") String merkleRootHashHex) {
+        var cacheControl = CacheControl.maxAge(1, MINUTES)
+                .noTransform()
+                .mustRevalidate();
+
         return merkleRootHashService.isPresent(eventId, merkleRootHashHex)
                 .fold(problem -> {
                             return ResponseEntity
                                     .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
                                     .body(problem);
                         },
                         isMerkleRootPresentResult -> {
-                            return ResponseEntity.ok().body(isMerkleRootPresentResult);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(isMerkleRootPresentResult);
                         }
                 );
     }

--- a/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/ReferenceDataResource.java
+++ b/backend-services/voting-ledger-follower-app/src/main/java/org/cardano/foundation/voting/resource/ReferenceDataResource.java
@@ -4,12 +4,14 @@ import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cardano.foundation.voting.service.reference_data.ReferencePresentationService;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.zalando.problem.Problem;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.zalando.problem.Status.NOT_FOUND;
 
@@ -24,6 +26,10 @@ public class ReferenceDataResource {
     @RequestMapping(value = "/event/{eventId}", method = GET, produces = "application/json")
     @Timed(value = "resource.reference.event", histogram = true)
     public ResponseEntity<?> getEventByName(@PathVariable("eventId") String eventId) {
+        var cacheControl = CacheControl.maxAge(15, SECONDS)
+                .noTransform()
+                .mustRevalidate();
+
         return referencePresentationService.findEventReference(eventId)
                 .fold(problem -> {
                             return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
@@ -36,12 +42,18 @@ public class ReferenceDataResource {
                                         .withStatus(NOT_FOUND)
                                         .build();
 
-                                return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                                return ResponseEntity
+                                        .status(problem.getStatus().getStatusCode())
+                                        .cacheControl(cacheControl)
+                                        .body(problem);
                             }
 
                             var eventPresentation = maybeEventPresentation.orElseThrow();
 
-                            return ResponseEntity.ok().body(eventPresentation);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(eventPresentation);
                         }
                 );
     }
@@ -49,12 +61,22 @@ public class ReferenceDataResource {
     @RequestMapping(value = "/event", method = GET, produces = "application/json")
     @Timed(value = "resource.reference.events", histogram = true)
     public ResponseEntity<?> events() {
+        var cacheControl = CacheControl.maxAge(15, SECONDS)
+                .noTransform()
+                .mustRevalidate();
+
         return referencePresentationService.eventsSummaries()
                 .fold(problem -> {
-                            return ResponseEntity.status(problem.getStatus().getStatusCode()).body(problem);
+                            return ResponseEntity
+                                    .status(problem.getStatus().getStatusCode())
+                                    .cacheControl(cacheControl)
+                                    .body(problem);
                         },
                         eventSummaries -> {
-                            return ResponseEntity.ok().body(eventSummaries);
+                            return ResponseEntity
+                                    .ok()
+                                    .cacheControl(cacheControl)
+                                    .body(eventSummaries);
                         }
                 );
     }


### PR DESCRIPTION
Fixes #285

```
mati@Mateuszs-MacBook-Pro cf-voting-app % curl -v  http://localhost:9090/api/blockchain/tip
*   Trying 127.0.0.1:9090...
* Connected to localhost (127.0.0.1) port 9090 (#0)
> GET /api/blockchain/tip HTTP/1.1
> Host: localhost:9090
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< Cache-Control: max-age=15, must-revalidate, no-transform
< ETag: "065822ac63aaf7fb85255bdaa2fee556f"
< Content-Type: application/json;charset=UTF-8
< Content-Length: 146
< Date: Fri, 22 Sep 2023 15:48:48 GMT
<

{"absoluteSlot":39714512,"hash":"74a4bed38baf2cd8469ef3b17042b648e42a190fedcf8d113d68862b9eab5aa1","epochNo":95,"network":"PREPROD","synced":true}%
```