### PR TITLE
fix: cip-30 parser 0.0.11 upgrade.

### DIFF
--- a/backend-services/user-verification-service/build.gradle.kts
+++ b/backend-services/user-verification-service/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
 
 	runtimeOnly("org.postgresql:postgresql")
 
-	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.10")
+	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.11")
 
 	// spring-boot overridden dependencies:
     runtimeOnly("com.h2database:h2:2.2.224") // GraalVM compatibility

--- a/backend-services/voting-app/build.gradle.kts
+++ b/backend-services/voting-app/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 	runtimeOnly("org.postgresql:postgresql")
 
 	implementation("org.cardanofoundation:merkle-tree-java:0.0.7")
-	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.10")
+	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.11")
 
     // spring-boot overridden dependencies:
     runtimeOnly("com.h2database:h2:2.2.224") // GraalVM compatibility

--- a/backend-services/voting-ledger-follower-app/build.gradle.kts
+++ b/backend-services/voting-ledger-follower-app/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
 
 	runtimeOnly("org.postgresql:postgresql")
 
-	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.10")
+	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.11")
 
     // spring-boot overridden dependencies:
     runtimeOnly("com.h2database:h2:2.2.224") // GraalVM compatibility

--- a/backend-services/voting-verification-app/build.gradle.kts
+++ b/backend-services/voting-verification-app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
 	implementation("io.vavr:vavr:0.10.4")
 
 	implementation("org.cardanofoundation:merkle-tree-java:0.0.7")
-	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.10")
+	implementation("org.cardanofoundation:cip30-data-signature-parser:0.0.11")
 }
 
 tasks.withType<Test> {

--- a/scripts/cip30_debug.sc
+++ b/scripts/cip30_debug.sc
@@ -1,7 +1,7 @@
 // brew install amm
 // amm cip30_debug.sc
 
-import $ivy.`org.cardanofoundation:cip30-data-signature-parser:0.0.10`
+import $ivy.`org.cardanofoundation:cip30-data-signature-parser:0.0.11`
 
 import $ivy.`org.slf4j:slf4j-simple:2.0.9`
 


### PR DESCRIPTION
Typhon Wallet is fixed both by the Typhon Wallet but we also not using KID4 anymore and only address from the protected headers field.

```
❯ amm cip30_debug.sc 84584da30127045820c4821499cef96eda9c00cdd0bfbcd2abf7d09436ad424ac7288653a8b42520146761646472657373581de01d813fd4ab9c1e5f7a35da16f75c2e664edfb2a127fc17a4a7ebbfeea166686173686564f44568656c6c6f5840c0d5f54ab847cb78e8aeff10691bb1dcc5eec9a52fbf9011a0cfe89a51c53c2e22f408708da3a2fb35bf8f518f63e79ae8388f12b198cb1bdbd0d40b72081b0d a4010103272006215820c4821499cef96eda9c00cdd0bfbcd2abf7d09436ad424ac7288653a8b4252014

valid: true
Address: stake_test1uqwcz0754wwpuhm6xhdpda6u9enyahaj5ynlc9ay5l4mlms4pyqyg
Message: hello
```
