### PR TITLE
fix: typhon is not CIP-30 compatible, there is typhoncip30 wallet.

### DIFF
--- a/deploy/cf-cardano-summit-2023-ui/templates/deployment.yaml
+++ b/deploy/cf-cardano-summit-2023-ui/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: REACT_APP_EVENT_ID
               value: {{ .Values.eventId }}
             - name: REACT_APP_SUPPORTED_WALLETS
-              value: {{ .Values.supportedWallets | default "flint,eternl,nami,typhon,yoroi,nufi,gerowallet,lace" }}
+              value: {{ .Values.supportedWallets | default "flint,eternl,nami,typhoncip30,yoroi,nufi,gerowallet,lace" }}
             - name: REACT_APP_VERSION
               value: {{ .Values.image.tag }}
             - name: REACT_APP_DISCORD_CHANNEL_URL

--- a/ui/cip-1694/.env.example
+++ b/ui/cip-1694/.env.example
@@ -6,4 +6,4 @@ REACT_APP_TARGET_NETWORK=PREPROD
 
 REACT_APP_EVENT_ID=CIP-1694_Pre_Ratification_4619
 
-REACT_APP_SUPPORTED_WALLETS=flint,eternl,nami,typhon,yoroi,nufi,gerowallet,lace
+REACT_APP_SUPPORTED_WALLETS=flint,eternl,nami,typhoncip30,yoroi,nufi,gerowallet,lace

--- a/ui/cip-1694/Dockerfile
+++ b/ui/cip-1694/Dockerfile
@@ -13,7 +13,7 @@ ENV NODE_ENV="production" \
     REACT_APP_TARGET_NETWORK="PREPROD" \
     REACT_APP_EVENT_ID=${REACT_APP_EVENT_ID} \
     REACT_APP_CATEGORY_ID=${REACT_APP_CATEGORY_ID} \
-    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhon,yoroi,nufi,gerowallet,lace"
+    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhoncip30,yoroi,nufi,gerowallet,lace"
 
 # Add a work directory
 WORKDIR /app

--- a/ui/summit-2023/Dockerfile
+++ b/ui/summit-2023/Dockerfile
@@ -23,7 +23,7 @@ ENV NODE_ENV="production" \
     REACT_APP_COMMIT_HASH="INJECT_COMMIT_HASH" \
     REACT_APP_DISCORD_CHANNEL_URL="https://discord.gg/FeCbA2wYF8" \
     REACT_APP_DISCORD_BOT_URL="https://discord.gg/65Hq3gqFwE" \
-    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhon,yoroi,nufi,gerowallet,lace"
+    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhoncip30,yoroi,nufi,gerowallet,lace"
 
 # Copy built assets from builder
 COPY --from=builder /app/build /usr/share/nginx/html

--- a/ui/verification-app/Dockerfile
+++ b/ui/verification-app/Dockerfile
@@ -13,7 +13,7 @@ ENV NODE_ENV="production" \
     REACT_APP_TARGET_NETWORK="PREPROD" \
     REACT_APP_EVENT_ID=${REACT_APP_EVENT_ID} \
     REACT_APP_CATEGORY_ID=${REACT_APP_CATEGORY_ID} \
-    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhon,yoroi,nufi,gerowallet,lace"
+    REACT_APP_SUPPORTED_WALLETS="flint,eternl,nami,typhoncip30,yoroi,nufi,gerowallet,lace"
 
 # Add a work directory
 WORKDIR /app


### PR DESCRIPTION
Turns out a proper CIP-30 compatible key for typhon is "typhoncip30" and not "typhon". "Typhon" is a minimalistic wallet that will likely be soon deprecated.

![image](https://github.com/cardano-foundation/cf-cardano-ballot/assets/335933/1c5503e8-d318-4025-ae59-8be6d340bbf3)
