### PR TITLE
fix(cip-1694-ui): after event closes fixes

### DIFF
--- a/ui/cip-1694/src/components/common/Header/__tests__/Header.test.tsx
+++ b/ui/cip-1694/src/components/common/Header/__tests__/Header.test.tsx
@@ -336,7 +336,7 @@ describe('For ongoing event:', () => {
     await waitFor(async () => {
       expect(mockToast).toBeCalledWith(
         <Toast
-          message="Failed to fecth chain tip"
+          message="Failed to fetch chain tip"
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />

--- a/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/ConnectWalletButton.tsx
@@ -1,19 +1,16 @@
 /* eslint-disable indent */
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import toast from 'react-hot-toast';
 import cn from 'classnames';
 import { Button } from '@mui/material';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import BlockIcon from '@mui/icons-material/Block';
 import {
   useCardano,
   ConnectWalletButton as CFConnectWalletButton,
   getWalletIcon,
 } from '@cardano-foundation/cardano-connect-with-wallet';
 import { setConnectedWallet, setIsConnectWalletModalVisible } from 'common/store/userSlice';
-import { Toast } from 'components/common/Toast/Toast';
 import { RootState } from 'common/store';
 import { clearUserInSessionStorage } from 'common/utils/session';
 import { resolveCardanoNetwork } from 'common/utils/common';
@@ -30,20 +27,6 @@ export const ConnectWalletButton = ({ isMobileMenu = false }) => {
   const supportedWallets = installedExtensions.filter((installedWallet) =>
     env.SUPPORTED_WALLETS.includes(installedWallet)
   );
-
-  // TODO: move to providers level and throw?
-  useEffect(() => {
-    if (supportedWallets.length === 0) {
-      toast(
-        <Toast
-          error
-          message="No supported wallets specified"
-          icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
-        />
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     const init = async () => {

--- a/ui/cip-1694/src/components/common/Header/components/HeaderActions.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/HeaderActions.tsx
@@ -46,7 +46,7 @@ export const HeaderActions = ({ isMobileMenu = false, onClick, showNavigationIte
     } catch (error) {
       toast(
         <Toast
-          message="Failed to fecth chain tip"
+          message="Failed to fetch chain tip"
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />

--- a/ui/cip-1694/src/components/common/Header/components/__tests__/ConnectWalletButton.test.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/__tests__/ConnectWalletButton.test.tsx
@@ -11,7 +11,6 @@ var clearMock = jest.fn();
 import '@testing-library/jest-dom';
 import React, { useEffect } from 'react';
 import { expect } from '@jest/globals';
-import BlockIcon from '@mui/icons-material/Block';
 import { waitFor, cleanup } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { UserState } from 'common/store/types';
@@ -19,7 +18,6 @@ import { ROUTES } from 'common/routes';
 import { renderWithProviders } from 'test/mockProviders';
 import { eventMock_active, useCardanoMock } from 'test/mocks';
 import { CustomRouter } from 'test/CustomRouter';
-import { Toast } from 'components/common/Toast/Toast';
 import { USER_SESSION_KEY } from 'common/utils/session';
 import { ConnectWalletButton } from '../ConnectWalletButton';
 import * as envFile from '../../../../../env';
@@ -64,28 +62,6 @@ describe('ConnectWalletButton', () => {
   afterEach(() => {
     jest.clearAllMocks();
     cleanup();
-  });
-
-  test('should display toast if no wallets provided', async () => {
-    envFile.env.SUPPORTED_WALLETS = [];
-    envFile.env.TARGET_NETWORK = 'Preprod';
-    const history = createMemoryHistory({ initialEntries: [ROUTES.INTRO] });
-    renderWithProviders(
-      <CustomRouter history={history}>
-        <ConnectWalletButton />
-      </CustomRouter>,
-      { preloadedState: { user: { event: eventMock_active } as UserState } }
-    );
-
-    await waitFor(async () => {
-      expect(mockToast).toBeCalledWith(
-        <Toast
-          message="No supported wallets specified"
-          error
-          icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
-        />
-      );
-    });
   });
 
   test('should handle onConnect', async () => {

--- a/ui/cip-1694/src/components/common/Header/components/__tests__/HeaderActions.test.tsx
+++ b/ui/cip-1694/src/components/common/Header/components/__tests__/HeaderActions.test.tsx
@@ -113,7 +113,7 @@ describe('HeaderActions', () => {
     await waitFor(async () => {
       expect(mockToast).toBeCalledWith(
         <Toast
-          message={'Failed to fecth chain tip'}
+          message={'Failed to fetch chain tip'}
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />
@@ -133,7 +133,7 @@ describe('HeaderActions', () => {
     await waitFor(async () => {
       expect(mockToast).toBeCalledWith(
         <Toast
-          message={'Failed to fecth chain tip'}
+          message={'Failed to fetch chain tip'}
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />
@@ -152,7 +152,7 @@ describe('HeaderActions', () => {
     await waitFor(async () => {
       expect(mockToast).toBeCalledWith(
         <Toast
-          message={'Failed to fecth chain tip'}
+          message={'Failed to fetch chain tip'}
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />

--- a/ui/cip-1694/src/pages/Leaderboard/Leaderboard.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/Leaderboard.tsx
@@ -29,7 +29,7 @@ export const Leaderboard = () => {
     try {
       setStats((await leaderboardService.getStats(event?.categories?.[0]?.id))?.proposals);
     } catch (error) {
-      const message = `Failed to fecth stats: ${error?.message || error?.toString()}`;
+      const message = `Failed to fetch stats: ${error?.message || error?.toString()}`;
       toast(
         <Toast
           error

--- a/ui/cip-1694/src/pages/Leaderboard/__tests__/Leaderboard.test.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/__tests__/Leaderboard.test.tsx
@@ -190,7 +190,7 @@ describe('For the event that has already finished', () => {
     await waitFor(async () => {
       expect(mockToast).toBeCalledWith(
         <Toast
-          message={`Failed to fecth stats: ${error}`}
+          message={`Failed to fetch stats: ${error}`}
           error
           icon={<BlockIcon style={{ fontSize: '19px', color: '#F5F9FF' }} />}
         />

--- a/ui/cip-1694/src/pages/Vote/components/ConfirmWithWalletSignatureModal/ConfirmWithWalletSignatureModal.tsx
+++ b/ui/cip-1694/src/pages/Vote/components/ConfirmWithWalletSignatureModal/ConfirmWithWalletSignatureModal.tsx
@@ -4,7 +4,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import CloseIcon from '@mui/icons-material/Close';
 import DialogTitle from '@mui/material/DialogTitle';
-import { Box, Button, IconButton, Typography } from '@mui/material';
+import { Box, Button, IconButton, Typography, CircularProgress } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import styles from './ConfirmWithWalletSignatureModal.module.scss';
 
@@ -12,6 +12,8 @@ type ConfirmWithWalletSignatureModalProps = {
   name: string;
   id: string;
   openStatus: boolean;
+  isConfirming: boolean;
+  showCloseBtn: boolean;
   title: string;
   description: string | React.ReactNode;
   onConfirm: () => void;
@@ -19,7 +21,7 @@ type ConfirmWithWalletSignatureModalProps = {
 };
 
 export const ConfirmWithWalletSignatureModal = (props: ConfirmWithWalletSignatureModalProps) => {
-  const { name, id, openStatus, title, description, onConfirm, onCloseFn } = props;
+  const { name, id, openStatus, title, description, onConfirm, onCloseFn, isConfirming, showCloseBtn } = props;
 
   return (
     <Dialog
@@ -35,14 +37,16 @@ export const ConfirmWithWalletSignatureModal = (props: ConfirmWithWalletSignatur
         data-testid="confirm-with-signature-title"
       >
         {title}
-        <IconButton
-          aria-label="close"
-          onClick={onCloseFn}
-          className={styles.closeBtn}
-          data-testid="confirm-with-signature-close"
-        >
-          <CloseIcon className={styles.closeIcon} />
-        </IconButton>
+        {showCloseBtn && (
+          <IconButton
+            aria-label="close"
+            onClick={onCloseFn}
+            className={styles.closeBtn}
+            data-testid="confirm-with-signature-close"
+          >
+            <CloseIcon className={styles.closeIcon} />
+          </IconButton>
+        )}
       </DialogTitle>
       <DialogContent
         sx={{ padding: { xs: '20px', md: '0px 30px 30px 30px' } }}
@@ -79,10 +83,16 @@ export const ConfirmWithWalletSignatureModal = (props: ConfirmWithWalletSignatur
                   size="large"
                   variant="contained"
                   onClick={() => onConfirm()}
-                  sx={{}}
+                  disabled={isConfirming}
                   data-testid="confirm-with-signature-cta"
                 >
                   Confirm
+                  {isConfirming && (
+                    <CircularProgress
+                      size={20}
+                      sx={{ marginLeft: '10px' }}
+                    />
+                  )}
                 </Button>
               </Box>
             </Grid>

--- a/ui/summit-2023/src/pages/Leaderboard/Leaderboard.tsx
+++ b/ui/summit-2023/src/pages/Leaderboard/Leaderboard.tsx
@@ -29,11 +29,11 @@ const Leaderboard = () => {
         setStats(response.categories);
       });
     } catch (error) {
-      const message = `Failed to fecth stats: ${error?.message || error?.toString()}`;
+      const message = `Failed to fetch stats: ${error?.message || error?.toString()}`;
       if (process.env.NODE_ENV === 'development') {
         console.log(message);
       }
-      eventBus.publish('showToast', 'Failed to fecth stats', 'error');
+      eventBus.publish('showToast', 'Failed to fetch stats', 'error');
     }
   }, []);
 


### PR DESCRIPTION
- [x] fix typo in `Failed to fetch chain tip` and `Failed to fetch stats` messages
- [x] remove `No supported wallets specified` toast
- [x] react to activeCategoryId change when showing confirm with signature modal
- [x] do not show receipt button if event is finished
- [x] show pagination if receipt is fetched for current category or event is finished
- [x] do not show close button in `confirm with signature` modal when event is finished
- [x] add loader for the `confirm` cta in `confirm with signature` modal
- [x] update tests