### PR TITLE
feat(cip-1694-ui): change typhon wallet name, fix typo

### DIFF
--- a/ui/cip-1694/jest.config.ts
+++ b/ui/cip-1694/jest.config.ts
@@ -5,8 +5,8 @@ export default {
   coverageThreshold: {
     global: {
       branches: 84,
-      functions: 94,
-      lines: 93,
+      functions: 93,
+      lines: 92,
       statements: 93,
     },
   },

--- a/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/ui/cip-1694/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -39,6 +39,15 @@ export const ConnectWalletModal = (props: ConnectWalletModalProps) => {
   const supportedWallets = installedExtensions
     .filter((installedWallet) => env.SUPPORTED_WALLETS.includes(installedWallet))
     .sort((a, b) => a.localeCompare(b));
+
+  useLayoutEffect(() => {
+    setTimeout(() => {
+      Array.from(document.querySelector("[data-testid='connect-wallet-list']")?.children || [])?.forEach((wallet) => {
+        const content = wallet.innerHTML;
+        wallet.innerHTML = content.replace('Typhoncip30', 'Typhon');
+      });
+    }, 0);
+  }, []);
 
   return (
     <Dialog

--- a/ui/cip-1694/src/components/ConnectWalletModal/__tests__/ConnectWalletModal.test.tsx
+++ b/ui/cip-1694/src/components/ConnectWalletModal/__tests__/ConnectWalletModal.test.tsx
@@ -46,7 +46,10 @@ describe('ConnectWalletModal', () => {
     id: 'connect-wallet-modal',
     title: 'Connect wallet',
     description: `In order to participate, first you will need to connect your wallet. Following wallets are accepted: ${mockSupportedWallets
-      ?.map((w) => `${w[0].toUpperCase()}${w.slice(1)}`)
+      ?.map((w) => {
+        const walletName = w.replace('typhoncip30', 'Typhon');
+        return `${walletName[0].toUpperCase()}${walletName.slice(1)}`;
+      })
       ?.join(', ')}.`,
     onConnectWallet: jest.fn(),
     onConnectWalletError: jest.fn(),

--- a/ui/cip-1694/src/components/Content/Content.tsx
+++ b/ui/cip-1694/src/components/Content/Content.tsx
@@ -46,25 +46,31 @@ export const Content = () => {
     <Box className={styles.content}>
       <CssBaseline />
       <PageRoutes />
-      <ConnectWalletModal
-        installedExtensions={installedExtensions}
-        openStatus={isConnectWalletModalVisible}
-        onCloseFn={onCloseFn}
-        name="connect-wallet-list"
-        id="connect-wallet-list"
-        title="Connect wallet"
-        description={
-          <>
-            In order to participate, first you will need to connect your wallet. Following wallets are accepted:{' '}
-            <span style={{ fontWeight: '500' }}>
-              {env.SUPPORTED_WALLETS?.map((w) => `${w[0].toUpperCase()}${w.slice(1)}`)?.join(', ')}
-            </span>
-            .
-          </>
-        }
-        onConnectWallet={onConnectWallet}
-        onConnectWalletError={onConnectWalletError}
-      />
+      {isConnectWalletModalVisible && (
+        <ConnectWalletModal
+          installedExtensions={installedExtensions}
+          openStatus={isConnectWalletModalVisible}
+          onCloseFn={onCloseFn}
+          name="connect-wallet-list"
+          id="connect-wallet-list"
+          title="Connect wallet"
+          description={
+            <>
+              In order to participate, first you will need to connect your wallet. Following wallets are accepted:{' '}
+              <span style={{ fontWeight: '500' }}>
+                {env.SUPPORTED_WALLETS?.map((w) => {
+                  const walletName = w.replace('typhoncip30', 'Typhon');
+                  console.log(w);
+                  return `${walletName[0].toUpperCase()}${walletName.slice(1)}`;
+                })?.join(', ')}
+              </span>
+              .
+            </>
+          }
+          onConnectWallet={onConnectWallet}
+          onConnectWalletError={onConnectWalletError}
+        />
+      )}
     </Box>
   );
 };

--- a/ui/cip-1694/src/components/Content/__tests__/Content.test.tsx
+++ b/ui/cip-1694/src/components/Content/__tests__/Content.test.tsx
@@ -94,7 +94,10 @@ describe('ConnectWalletModal', () => {
     expect(within(modal).queryByTestId('connected-wallet-modal-title')).toHaveTextContent('Connect wallet');
     expect(within(modal).queryByTestId('connected-wallet-modal-description')).toHaveTextContent(
       `In order to participate, first you will need to connect your wallet. Following wallets are accepted: ${mockSupportedWallets
-        ?.map((w) => `${w[0].toUpperCase()}${w.slice(1)}`)
+        ?.map((w) => {
+          const walletName = w.replace('typhoncip30', 'Typhon');
+          return `${walletName[0].toUpperCase()}${walletName.slice(1)}`;
+        })
         ?.join(', ')}.`
     );
 

--- a/ui/cip-1694/src/components/EventTime/EventTime.module.scss
+++ b/ui/cip-1694/src/components/EventTime/EventTime.module.scss
@@ -9,6 +9,7 @@
   line-height: 22px;
   text-align: left;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .skeleton {

--- a/ui/cip-1694/src/pages/Vote/Vote.tsx
+++ b/ui/cip-1694/src/pages/Vote/Vote.tsx
@@ -587,7 +587,7 @@ export const VotePage = () => {
         isConfirming={isConfirmingWithSignature}
         description={
           <>
-            We need to check if you’ve already submitted yor ballot.
+            We need to check if you’ve already submitted your ballot.
             <br />
             You will see a pop-up message from your wallet.
             <br />

--- a/ui/cip-1694/src/pages/Vote/__tests__/Vote.test.tsx
+++ b/ui/cip-1694/src/pages/Vote/__tests__/Vote.test.tsx
@@ -943,7 +943,7 @@ describe('For ongoing event:', () => {
       'Wallet signature'
     );
     expect(await within(confirmationModal).findByTestId('confirm-with-signature-description')).toHaveTextContent(
-      'We need to check if you’ve already submitted yor ballot.You will see a pop-up message from your wallet.Please confirm with your wallet signature.'
+      'We need to check if you’ve already submitted your ballot.You will see a pop-up message from your wallet.Please confirm with your wallet signature.'
     );
     const confirmCta = await within(confirmationModal).findByTestId('confirm-with-signature-cta');
     expect(confirmCta).toHaveTextContent('Confirm');
@@ -1010,7 +1010,7 @@ describe('For ongoing event:', () => {
       'Wallet signature'
     );
     expect(await within(confirmationModal).findByTestId('confirm-with-signature-description')).toHaveTextContent(
-      'We need to check if you’ve already submitted yor ballot.You will see a pop-up message from your wallet.Please confirm with your wallet signature.'
+      'We need to check if you’ve already submitted your ballot.You will see a pop-up message from your wallet.Please confirm with your wallet signature.'
     );
     const confirmCta = await within(confirmationModal).findByTestId('confirm-with-signature-cta');
     expect(confirmCta).toHaveTextContent('Confirm');


### PR DESCRIPTION
- [x] hack typhon wallet name
- [x] fix typo in the wallet signature modal 

<img width="1071" alt="Screenshot 2023-11-02 at 13 32 37" src="https://github.com/cardano-foundation/cf-cardano-ballot/assets/7934077/00afb993-acc9-4793-a887-f3608be4dd8d">
