### PR TITLE
fix(cip-1694-ui): change leaderboard stats

### DIFF
--- a/ui/cip-1694/package-lock.json
+++ b/ui/cip-1694/package-lock.json
@@ -31,6 +31,7 @@
         "@types/react-dom": "^18.2.4",
         "@types/testing-library__jest-dom": "^5.14.9",
         "@types/uuid": "^9.0.2",
+        "bignumber.js": "^4.0.4",
         "classnames": "^2.3.2",
         "css-mediaquery": "^0.1.2",
         "expect": "^29.6.2",
@@ -7534,6 +7535,14 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
+      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==",
       "engines": {
         "node": "*"
       }

--- a/ui/cip-1694/package.json
+++ b/ui/cip-1694/package.json
@@ -29,6 +29,7 @@
     "@types/react-dom": "^18.2.4",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@types/uuid": "^9.0.2",
+    "bignumber.js": "^4.0.4",
     "classnames": "^2.3.2",
     "css-mediaquery": "^0.1.2",
     "expect": "^29.6.2",

--- a/ui/cip-1694/src/components/Tooltip/Tooltip.module.scss
+++ b/ui/cip-1694/src/components/Tooltip/Tooltip.module.scss
@@ -1,0 +1,23 @@
+.tooltip {
+  background: #1d439b !important;
+  padding: 12px 16px !important;
+  margin: 0px !important;
+  &.tooltipFullWidth {
+    max-width: 100% !important;
+  }
+  .tooltipTitle {
+    font-size: 18px !important;
+    font-weight: 600 !important;
+    line-height: 22px !important;
+    letter-spacing: 0em !important;
+    text-align: left !important;
+  }
+
+  .tooltipDescription {
+    font-size: 16px !important;
+    font-weight: 400 !important;
+    line-height: 22px !important;
+    letter-spacing: 0em !important;
+    text-align: left !important;
+  }
+}

--- a/ui/cip-1694/src/components/Tooltip/Tooltip.tsx
+++ b/ui/cip-1694/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import cn from 'classnames';
+import { Grid, Tooltip as MuiTooltip, Typography } from '@mui/material';
+import styles from './Tooltip.module.scss';
+
+export const Tooltip = ({
+  title,
+  children,
+  fullWidth = false,
+}: {
+  title: React.ReactNode;
+  children?: React.ReactElement;
+  fullWidth?: boolean;
+}) => (
+  <MuiTooltip
+    classes={{ tooltip: cn(styles.tooltip, { [styles.tooltipFullWidth]: fullWidth }) }}
+    title={
+      <Grid
+        container
+        direction="column"
+        alignItems="left"
+        gap={'8px'}
+      >
+        <Typography
+          className={styles.tooltipDescription}
+          variant="h4"
+        >
+          {title}
+        </Typography>
+      </Grid>
+    }
+  >
+    {children}
+  </MuiTooltip>
+);

--- a/ui/cip-1694/src/pages/Leaderboard/__tests__/Leaderboard.test.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/__tests__/Leaderboard.test.tsx
@@ -8,6 +8,7 @@ var mockToast = jest.fn();
 /* eslint-disable import/imports-first */
 import 'whatwg-fetch';
 import '@testing-library/jest-dom';
+import BigNumber from 'bignumber.js';
 import { expect } from '@jest/globals';
 import { screen, within, waitFor, cleanup } from '@testing-library/react';
 import BlockIcon from '@mui/icons-material/Block';
@@ -21,7 +22,7 @@ import { renderWithProviders } from 'test/mockProviders';
 import { useCardanoMock, eventMock_finished, voteStats, eventMock_active, chainTipMock } from 'test/mocks';
 import { CustomRouter } from 'test/CustomRouter';
 import { Leaderboard } from '../Leaderboard';
-import { proposalColorsMap, getPercentage, formatNumber } from '../utils';
+import { proposalColorsMap, getPercentage, formatNumber, lovelacesToAdaString } from '../utils';
 
 jest.mock('react-minimal-pie-chart', () => ({
   PieChart: mockPieChart,
@@ -119,7 +120,7 @@ describe('For the event that has already finished', () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total number of ballot submissions ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();
@@ -180,8 +181,8 @@ describe('For the event that has already finished', () => {
 
     const stats = Object.entries(voteStats.proposals);
     const statsSum = Object.values(voteStats.proposals)?.reduce(
-      (acc, { votingPower }) => (acc += BigInt(votingPower)),
-      BigInt(0)
+      (acc, { votingPower }) => (acc = acc.add(votingPower)),
+      new BigNumber(0)
     );
     const statsItems =
       eventMock_finished?.categories
@@ -205,16 +206,16 @@ describe('For the event that has already finished', () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total ballot power ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();
-      expect(pollStatsTileSummary.textContent).toEqual(formatNumber(statsSum));
+      expect(pollStatsTileSummary.textContent).toEqual(lovelacesToAdaString(statsSum));
 
       const pollStatsItems = within(pollStatsTile).queryAllByTestId('poll-stats-item-votingPower');
       for (const item in statsItems) {
         expect(pollStatsItems[item].textContent).toEqual(
-          `${capitalize(statsItems[item].name.toLowerCase())}${formatNumber(BigInt(stats[item][1].votingPower))}`
+          `${capitalize(statsItems[item].name.toLowerCase())}${lovelacesToAdaString(stats[item][1].votingPower)}`
         );
       }
 
@@ -227,7 +228,7 @@ describe('For the event that has already finished', () => {
 
       const currentlyVotingTileSummary = within(currentlyVotingTile).queryByTestId('tile-summary');
       expect(currentlyVotingTileSummary).not.toBeNull();
-      expect(currentlyVotingTileSummary.textContent).toEqual(formatNumber(statsSum));
+      expect(currentlyVotingTileSummary.textContent).toEqual(lovelacesToAdaString(statsSum));
 
       const currentlyVotingItems = within(currentlyVotingTile).queryAllByTestId('currently-voting-item-votingPower');
       for (const item in statsItems) {
@@ -318,7 +319,7 @@ describe('For the event that has already finished', () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total number of ballot submissions ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();
@@ -395,7 +396,7 @@ describe('For the event that has already finished', () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total ballot power ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();
@@ -506,7 +507,7 @@ describe("For the event that hasn't finished yet", () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total number of ballot submissions ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();
@@ -582,7 +583,7 @@ describe("For the event that hasn't finished yet", () => {
 
       const pollStatsTileTitle = within(pollStatsTile).queryByTestId('tile-title');
       expect(pollStatsTileTitle).not.toBeNull();
-      expect(pollStatsTileTitle.textContent).toEqual('Ballot stats');
+      expect(pollStatsTileTitle.textContent).toEqual('Total ballot power ');
 
       const pollStatsTileSummary = within(pollStatsTile).queryByTestId('tile-summary');
       expect(pollStatsTileSummary).not.toBeNull();

--- a/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.tsx
+++ b/ui/cip-1694/src/pages/Leaderboard/components/StatsTile.tsx
@@ -3,8 +3,8 @@ import { Grid, Typography } from '@mui/material';
 import styles from './StatsTile.module.scss';
 
 type StatsTilePorps = {
-  title: string | React.ReactElement;
-  summary: string | React.ReactElement;
+  title: React.ReactNode;
+  summary: React.ReactNode;
   children: React.ReactNode;
   dataTestId: string;
 };
@@ -14,7 +14,6 @@ export const StatsTile = ({ title, summary, children, dataTestId }: StatsTilePor
     <Grid
       data-testid={dataTestId}
       xs={12}
-      md={6}
       item
       className={styles.optionCard}
       padding={{ md: '30px', xs: '20px' }}

--- a/ui/cip-1694/src/pages/Leaderboard/utils.ts
+++ b/ui/cip-1694/src/pages/Leaderboard/utils.ts
@@ -1,4 +1,8 @@
+import BigNumber from 'bignumber.js';
 import { ProposalPresentation } from 'types/voting-ledger-follower-types';
+
+const LOVELACE_VALUE = 1_000_000;
+const DEFAULT_DECIMALS = 2;
 
 export const proposalColorsMap: Record<ProposalPresentation['name'], string> = {
   YES: '#43E4B7',
@@ -6,14 +10,18 @@ export const proposalColorsMap: Record<ProposalPresentation['name'], string> = {
   ABSTAIN: '#1D439B',
 };
 
-export const formatNumber = (number: number | bigint) =>
-  new Intl.NumberFormat('en-EN', { maximumFractionDigits: 3 }).format(number);
+export const formatNumber = (number: number | string | BigNumber) => new BigNumber(number).toFormat();
 
 export const getPercentage = (value: number | string, total: number | string) =>
-  parseFloat(formatNumber(Number((BigInt(value) * BigInt(100) * BigInt(100)) / BigInt(total)) / 100));
+  parseFloat(new BigNumber(value).times(100).dividedBy(total).toFixed(2));
 
 export const formatUTCDate = (date: string) => {
   if (!date) return '';
   const isoDate = new Date(date).toISOString();
   return `${isoDate.substring(0, 4)} ${isoDate.substring(11, 16)} UTC`;
 };
+
+export const lovelacesToAdaString = (
+  lovelaces: string | BigNumber | number,
+  decimalValues: number = DEFAULT_DECIMALS
+): string => `${new BigNumber(lovelaces).dividedBy(LOVELACE_VALUE).toFormat(decimalValues)} ₳`;

--- a/ui/cip-1694/src/pages/Vote/components/VoteReceipt/components/ReceiptInfo/ReceiptInfo.tsx
+++ b/ui/cip-1694/src/pages/Vote/components/VoteReceipt/components/ReceiptInfo/ReceiptInfo.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import Grid from '@mui/material/Grid';
-import { Button, IconButton, Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Button, IconButton, useMediaQuery, useTheme } from '@mui/material';
 import QrCodeIcon from '@mui/icons-material/QrCode';
 import ReplayIcon from '@mui/icons-material/Replay';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { FinalityScore, Status, VoteReceipt } from 'types/voting-app-types';
+import { Tooltip } from 'components/Tooltip/Tooltip';
 import { InfoPanelTypes, InfoPanel } from '../../../InfoPanel/InfoPanel';
 import styles from './ReceiptInfo.module.scss';
 
@@ -21,24 +22,7 @@ const InfoPanelTitle = ({ title, children }: { title: string; children?: React.R
     color="#061D3C"
   >
     {title} {children}
-    <Tooltip
-      classes={{ tooltip: styles.tooltip }}
-      title={
-        <Grid
-          container
-          direction="column"
-          alignItems="left"
-          gap={'8px'}
-        >
-          <Typography
-            className={styles.tooltipDescription}
-            variant="h4"
-          >
-            Assurance levels will update according to the finality of the transaction on-chain.
-          </Typography>
-        </Grid>
-      }
-    >
+    <Tooltip title="Assurance levels will update according to the finality of the transaction on-chain.">
       <IconButton sx={{ margin: '-8px' }}>
         <InfoOutlinedIcon style={{ color: '#39486CA6', fontSize: '19px' }} />
       </IconButton>

--- a/ui/cip-1694/src/pages/Vote/components/VoteReceipt/components/ReceiptItem/ReceipItem.tsx
+++ b/ui/cip-1694/src/pages/Vote/components/VoteReceipt/components/ReceiptItem/ReceipItem.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import cn from 'classnames';
 import Grid from '@mui/material/Grid';
-import { IconButton, Tooltip, Typography } from '@mui/material';
+import { IconButton, Typography } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import { Tooltip } from 'components/Tooltip/Tooltip';
 import {
   AdvancedFullFieldsToDisplayArrayKeys,
   FieldsToDisplayArrayKeys,
@@ -41,24 +41,7 @@ export const ReceiptItem = ({
           alignItems="center"
         >
           <span data-testid={`${dataTestId}-title`}>{labelTransformerMap[name]}</span>
-          <Tooltip
-            classes={{ tooltip: styles.tooltip }}
-            title={
-              <Grid
-                container
-                direction="column"
-                alignItems="left"
-                gap={'8px'}
-              >
-                <Typography
-                  className={styles.tooltipDescription}
-                  variant="h4"
-                >
-                  {description}
-                </Typography>
-              </Grid>
-            }
-          >
+          <Tooltip title={description}>
             <IconButton
               data-id={name}
               data-testid={`${dataTestId}-info-icon`}
@@ -84,15 +67,8 @@ export const ReceiptItem = ({
       >
         {name === 'id' || name === 'voterStakingAddress' ? (
           <Tooltip
-            classes={{ tooltip: cn(styles.tooltip, styles.tooltipFullWidth) }}
-            title={
-              <Typography
-                className={styles.tooltipDescription}
-                variant="h4"
-              >
-                {value}
-              </Typography>
-            }
+            fullWidth
+            title={value}
           >
             <span>{valueTransformerMap[name]?.(value) || value}</span>
           </Tooltip>


### PR DESCRIPTION
- [x] change the title Ballot stats on Q1 to: `Total number of ballot submissions: xxx`, add an info icon referring to the total number of ballot submissions with the following: `total number of ballots cast`
- [x] change lovelace for adas on the voting power Q3 and Q4
- [x] change the title Ballot stats on Q3 to: `Total ballot power:: xxx`, add an info icon referring to the total ballot power with the following: `total power of wallets determined by the amount of ada staked at the time of the Snapshot (November 21st, before 21:44 UTC).`
- [x] leave just 2 columns, one for total number of ballot submissions and the right one for ballot power.

![Uploading Untitled.png…]()
<img width="341" alt="Screenshot 2023-12-09 at 22 10 45" src="https://github.com/cardano-foundation/cf-cardano-ballot/assets/7934077/3cf380c1-dab7-4946-8227-2f583c47e137">

