### PR TITLE
feat: cleaner GET interface for KERI verifier service

### DIFF
--- a/backend-services/keri-ballot-verifier/src/verifier/verify.py
+++ b/backend-services/keri-ballot-verifier/src/verifier/verify.py
@@ -56,15 +56,18 @@ def setupVerifier(hby, hab, name, port, adminPort):
 
     return doers
 
+
 def createAdminApp(hby, hab, queries):
     # Set up Falcon administrative application
     adminApp = falcon.App(cors_enable=True)
     adminApp.add_route("/oobi", controllers.OOBIEnd(hby=hby))
-    adminApp.add_route("/keystate", controllers.KeyStateEnd(hby=hby, hab=hab, queries=queries))
+    adminApp.add_route("/keystate", controllers.KeyStateCreateEnd(hby=hby, hab=hab, queries=queries))
+    adminApp.add_route("/keystate/{pre}", controllers.KeyStateQueryEnd(hby=hby, hab=hab))
     adminApp.add_route("/verify", controllers.VerificationEnd(hab=hab))
     adminApp.add_route("/health", controllers.HealthEnd())
 
     return adminApp
+
 
 class Querier(doing.DoDoer):
 


### PR DESCRIPTION
Removes bodies from GET interfaces in place of path and query params. The OOBI should be URI encoded before passing as a param.

Also added missing unit tests for the key state update endpoints (for key rotation).

https://cardanofoundation.atlassian.net/browse/DTIS-961
https://cardanofoundation.atlassian.net/browse/DTIS-1014