### PR TITLE
build: keri verifier service build cleanup and deps

### DIFF
--- a/backend-services/keri-ballot-verifier/scripts/start_verifier.sh
+++ b/backend-services/keri-ballot-verifier/scripts/start_verifier.sh
@@ -2,7 +2,7 @@
 
 CONFIG_DIR="${VERIFIER_CONFIG_DIR:-$(pwd)}"
 STORE_DIR="${VERIFIER_STORE_DIR:-$(pwd)/store}"
-URL="${VERIFIER_URL:-http://localhost}"
+URL="${VERIFIER_URL:-http://localhost:5666}"
 PORT="${VERIFIER_PORT:-5666}"
 ADMIN_PORT="${VERIFIER_ADMIN_PORT:-5667}"
 
@@ -11,7 +11,7 @@ cat > $CONFIG_DIR/keri/cf/verifier.json <<EOF
 {
   "verifier": {
     "dt": "$(date -u +"%Y-%m-%dT%H:%M:%S.000000+00:00")",
-    "curls": ["${URL}:${PORT}"]
+    "curls": ["${URL}"]
   },
   "dt": "$(date -u +"%Y-%m-%dT%H:%M:%S.000000+00:00")",
   "iurls": [

--- a/backend-services/keri-ballot-verifier/scripts/start_verifier.sh
+++ b/backend-services/keri-ballot-verifier/scripts/start_verifier.sh
@@ -2,23 +2,16 @@
 
 CONFIG_DIR="${VERIFIER_CONFIG_DIR:-$(pwd)}"
 STORE_DIR="${VERIFIER_STORE_DIR:-$(pwd)/store}"
-INTERNAL_HOST=${VERIFIER_INTERNAL_HOST:-localhost}
-EXTERNAL_HOST=${VERIFIER_EXTERNAL_HOST:-localhost}
-URL="${VERIFIER_URL:-http://$EXTERNAL_HOST}"
+URL="${VERIFIER_URL:-http://localhost}"
 PORT="${VERIFIER_PORT:-5666}"
 ADMIN_PORT="${VERIFIER_ADMIN_PORT:-5667}"
-if [[ -z "${VERIFIER_SALT}" ]]; then
-  SALT=""
-else
-  SALT="--salt ${VERIFIER_SALT}"
-fi
 
 mkdir -p $CONFIG_DIR/keri/cf
 cat > $CONFIG_DIR/keri/cf/verifier.json <<EOF
 {
   "verifier": {
     "dt": "$(date -u +"%Y-%m-%dT%H:%M:%S.000000+00:00")",
-    "curls": ["tcp://${INTERNAL_HOST}:$((PORT-1))/", "${URL}:${PORT}"]
+    "curls": ["${URL}:${PORT}"]
   },
   "dt": "$(date -u +"%Y-%m-%dT%H:%M:%S.000000+00:00")",
   "iurls": [

--- a/backend-services/keri-ballot-verifier/setup.py
+++ b/backend-services/keri-ballot-verifier/setup.py
@@ -20,8 +20,8 @@ setup(
     },
     python_requires='>=3.10.4',
     install_requires=[
-        'hio>=0.6.12',
-        'keri @ git+https://git@github.com/cardano-foundation/keripy.git@86bd27168f5f9b09965c386aae28ea9719fe3158',
+        'hio==0.6.13',
+        'keri==1.2.0-dev10',
         'multicommand>=1.0.0'
     ],
     test_require=[


### PR DESCRIPTION
Should better support our deployment and removed some unnecessary env variables. Also locked to latest dev release of keripy which had the fix from our fork (there is no non-dev release yet).