### PR TITLE
fix: UTC dates no longer change depending on timezone

### DIFF
--- a/ui/summit-2024/src/utils/utils.ts
+++ b/ui/summit-2024/src/utils/utils.ts
@@ -153,14 +153,12 @@ const formatISODate = (isoDate: string): string | undefined => {
     year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-    timeZone: "UTC",
     hourCycle: "h23",
-    timeZoneName: "short",
   };
 
   const formatter = new Intl.DateTimeFormat("en-US", options);
 
-  return formatter.format(date);
+  return formatter.format(date) + " UTC";
 };
 
 export {


### PR DESCRIPTION
[JIRA TICKET](https://cardanofoundation.atlassian.net/browse/DTIS-1276)

The dates that come from the backend are already UTC. I changed the code so we just format the date and we don't do a time conversion based on the timezone where the code runs. 